### PR TITLE
Allow proper handover to Squeezenetwork

### DIFF
--- a/slimproto.c
+++ b/slimproto.c
@@ -27,6 +27,8 @@
 
 static log_level loglevel;
 
+#define SQUEEZENETWORK "mysqueezebox.com:3483"
+
 #define PORT 3483
 
 #define MAXBUF 4096
@@ -468,11 +470,18 @@ static void process_setd(u8_t *pkt, int len) {
 
 static void process_serv(u8_t *pkt, int len) {
 	struct serv_packet *serv = (struct serv_packet *)pkt;
-
+	
+	unsigned slimproto_port = 0;
+	char squeezeserver[] = SQUEEZENETWORK;
+	
+	if(pkt[4] == 0 && pkt[5] == 0 && pkt[6] == 0 && pkt[7] == 1) {
+		server_addr(squeezeserver, &new_server, &slimproto_port);
+	} else {
+		new_server = serv->server_ip;
+	}
+	
 	LOG_INFO("switch server");
-
-	new_server = serv->server_ip;
-
+	
 	if (len - sizeof(struct serv_packet) == 10) {
 		if (!new_server_cap) {
 			new_server_cap = malloc(SYNC_CAP_LEN + 10 + 1);


### PR DESCRIPTION
Handover to Squeezenetwork fails. Address 0.0.0.1 is not properly identified as reference to mysqueezebox.com

```
[06:18:34.401250] process:512 serv
[06:18:34.401368] process_serv:472 switch server
[06:18:34.501545] slimproto:910 switching server to 0.0.0.1:3483
[06:18:34.501668] slimproto:922 unable to connect to server 0
```

The issue was previously reported on code.google.com (imported to github: BjornW/squeezelite#102)

This commit fixes that issue.

This fix was previously posted in #7. However, I did a bit of reshuffling there, so it automatically closed...
