### PR TITLE
Make optional AAC support via libfaad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,12 @@ OPT_VIS     = -DVISEXPORT
 OPT_IR      = -DIR
 OPT_GPIO    = -DGPIO
 OPT_RPI     = -DRPI
+OPT_FAAD    = -DFAAD
 
 SOURCES = \
 	main.c slimproto.c buffer.c stream.c utils.c \
 	output.c output_alsa.c output_pa.c output_stdout.c output_pack.c decode.c \
-	flac.c pcm.c mad.c vorbis.c faad.c mpg.c
+	flac.c pcm.c mad.c vorbis.c mpg.c
 
 SOURCES_DSD      = dsd.c dop.c dsd2pcm/dsd2pcm.c
 SOURCES_FF       = ffmpeg.c
@@ -24,14 +25,16 @@ SOURCES_RESAMPLE = process.c resample.c
 SOURCES_VIS      = output_vis.c
 SOURCES_IR       = ir.c
 SOURCES_GPIO     = gpio.c
+SOURCES_FAAD     = faad.c
 
 LINK_LINUX       = -ldl
 LINK_RPI         = -lwiringPi
 
-LINKALL          = -lFLAC -lmad -lvorbisfile -lfaad -lmpg123
+LINKALL          = -lFLAC -lmad -lvorbisfile -lmpg123
 LINKALL_FF       = -lavcodec -lavformat -lavutil
 LINKALL_RESAMPLE = -lsoxr
 LINKALL_IR       = -llirc_client
+LINKALL_FAAD     = -lfaad
 
 DEPS             = squeezelite.h slimproto.h
 
@@ -63,6 +66,9 @@ ifeq (,$(findstring $(SOURCES_GPIO), $(SOURCES)))
 	SOURCES += $(SOURCES_GPIO)
 endif
 endif
+ifneq (,$(findstring $(OPT_FAAD), $(OPTS)))
+	SOURCES += $(SOURCES_FAAD)
+endif
 
 # add optional link options
 ifneq (,$(findstring $(OPT_LINKALL), $(OPTS)))
@@ -78,6 +84,9 @@ ifneq (,$(findstring $(OPT_IR), $(OPTS)))
 endif
 ifneq (,$(findstring $(OPT_RPI), $(OPTS)))
 	LDADD += $(LINK_RPI)
+endif
+ifneq (,$(findstring $(OPT_FAAD), $(OPTS)))
+	LDADD += $(LINKALL_FAAD)
 endif
 else
 # if not LINKALL and linux add LINK_LINUX

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OPT_VIS     = -DVISEXPORT
 OPT_IR      = -DIR
 OPT_GPIO    = -DGPIO
 OPT_RPI     = -DRPI
-OPT_FAAD    = -DFAAD
+OPT_NO_FAAD = -DNO_FAAD
 
 SOURCES = \
 	main.c slimproto.c buffer.c stream.c utils.c \
@@ -66,7 +66,7 @@ ifeq (,$(findstring $(SOURCES_GPIO), $(SOURCES)))
 	SOURCES += $(SOURCES_GPIO)
 endif
 endif
-ifneq (,$(findstring $(OPT_FAAD), $(OPTS)))
+ifeq (,$(findstring $(OPT_NO_FAAD), $(OPTS)))
 	SOURCES += $(SOURCES_FAAD)
 endif
 
@@ -85,7 +85,7 @@ endif
 ifneq (,$(findstring $(OPT_RPI), $(OPTS)))
 	LDADD += $(LINK_RPI)
 endif
-ifneq (,$(findstring $(OPT_FAAD), $(OPTS)))
+ifeq (,$(findstring $(OPT_NO_FAAD), $(OPTS)))
 	LDADD += $(LINKALL_FAAD)
 endif
 else

--- a/decode.c
+++ b/decode.c
@@ -165,8 +165,10 @@ void decode_init(log_level level, const char *include_codecs, const char *exclud
 	if (!strstr(exclude_codecs, "wma")	&& (!include_codecs || (order_codecs = strstr(include_codecs, "wma"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_ff("wma"));
 #endif
+#if FAAD
 	if (!strstr(exclude_codecs, "aac")	&& (!include_codecs || (order_codecs = strstr(include_codecs, "aac"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_faad());
+#endif
 	if (!strstr(exclude_codecs, "ogg")	&& (!include_codecs || (order_codecs = strstr(include_codecs, "ogg"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_vorbis());
 	if (!strstr(exclude_codecs, "flac") && (!include_codecs || (order_codecs = strstr(include_codecs, "flac"))))

--- a/decode.c
+++ b/decode.c
@@ -165,7 +165,7 @@ void decode_init(log_level level, const char *include_codecs, const char *exclud
 	if (!strstr(exclude_codecs, "wma")	&& (!include_codecs || (order_codecs = strstr(include_codecs, "wma"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_ff("wma"));
 #endif
-#if FAAD
+#ifndef NO_FAAD
 	if (!strstr(exclude_codecs, "aac")	&& (!include_codecs || (order_codecs = strstr(include_codecs, "aac"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_faad());
 #endif


### PR DESCRIPTION
This library isn't included in Fedora for legal reasons, so I'd like to be able to build squeezelite without it.