### PR TITLE
added -Y command line parameter to allow scaling of mixer output leve…

### DIFF
--- a/main.c
+++ b/main.c
@@ -265,7 +265,6 @@ int main(int argc, char **argv) {
 	char *namefile = NULL;
 	char *modelname = NULL;
 	extern bool pcm_check_header;
-	extern bool user_rates;
 	char *logfile = NULL;
 	u8_t mac[6];
 	unsigned stream_buf_size = STREAMBUF_SIZE;
@@ -488,9 +487,6 @@ int main(int argc, char **argv) {
 				}
 				if (dstr) {
 					rate_delay = atoi(dstr);
-				}
-				if (rates[0]) {
-					user_rates = true;
 				}
 			}
 			break;

--- a/output.c
+++ b/output.c
@@ -36,8 +36,6 @@ u8_t *silencebuf;
 u8_t *silencebuf_dsd;
 #endif
 
-bool user_rates = false;
-
 #define LOCK   mutex_lock(outputbuf->mutex)
 #define UNLOCK mutex_unlock(outputbuf->mutex)
 
@@ -380,12 +378,12 @@ void output_init_common(log_level level, const char *device, unsigned output_buf
 	output.error_opening = false;
 	output.idle_to = (u32_t) idle;
 
-	if (!test_open(output.device, output.supported_rates, user_rates)) {
-		LOG_ERROR("unable to open output device: %s", output.device);
-		exit(0);
-	}
-
-	if (user_rates) {
+	if (!rates[0]) {
+		if (!test_open(output.device, output.supported_rates)) {
+			LOG_ERROR("unable to open output device");
+			exit(0);
+		}
+	} else {
 		for (i = 0; i < MAX_SUPPORTED_SAMPLERATES; ++i) {
 			output.supported_rates[i] = rates[i];
 		}

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -278,7 +278,7 @@ static void alsa_close(void) {
 	}
 }
 
-bool test_open(const char *device, unsigned rates[], bool userdef_rates) {
+bool test_open(const char *device, unsigned rates[]) {
 	int err;
 	snd_pcm_t *pcm;
 	snd_pcm_hw_params_t *hw_params;
@@ -298,14 +298,12 @@ bool test_open(const char *device, unsigned rates[], bool userdef_rates) {
 	}
 
 	// find supported sample rates to enable client side resampling of non supported rates
-	if (!userdef_rates) {
-		unsigned i, ind;
-		unsigned ref[] TEST_RATES;
+	unsigned i, ind;
+	unsigned ref[] TEST_RATES;
 
-		for (i = 0, ind = 0; ref[i]; ++i) {
-			if (snd_pcm_hw_params_test_rate(pcm, hw_params, ref[i], 0) == 0) {
-				rates[ind++] = ref[i];
-			}
+	for (i = 0, ind = 0; ref[i]; ++i) {
+		if (snd_pcm_hw_params_test_rate(pcm, hw_params, ref[i], 0) == 0) {
+			rates[ind++] = ref[i];
 		}
 	}
 

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -62,6 +62,7 @@ static struct {
 	u8_t *write_buf;
 	const char *volume_mixer_name;
 	bool mixer_linear;
+	unsigned mixer_scaling;
 	snd_mixer_elem_t* mixer_elem;
 	snd_mixer_t *mixer_handle;
 	long mixer_min;
@@ -181,14 +182,22 @@ void list_mixers(const char *output_device) {
 static void set_mixer(bool setmax, float ldB, float rdB) {
 	int err;
 	long nleft, nright;
+   float dBscaling;
+   float ldBscaled;
+   float rdBscaled;
+
+   dBscaling = 50.0F * log10(alsa.mixer_scaling / 100.0F);
+   LOG_DEBUG("Volume scaling factor: %i -> %3.1fdB", alsa.mixer_scaling, dBscaling);
+   ldBscaled = ldB + dBscaling;
+   rdBscaled = rdB + dBscaling;
 	
 	if (alsa.mixer_linear) {
         long lraw, rraw;
         if (setmax) {
             lraw = rraw = alsa.mixer_max;
         } else {
-            lraw = ((ldB > -MINVOL_DB ? MINVOL_DB + floor(ldB) : 0) / MINVOL_DB * (alsa.mixer_max-alsa.mixer_min)) + alsa.mixer_min;
-            rraw = ((rdB > -MINVOL_DB ? MINVOL_DB + floor(rdB) : 0) / MINVOL_DB * (alsa.mixer_max-alsa.mixer_min)) + alsa.mixer_min;
+            lraw = ((ldBscaled > -MINVOL_DB ? MINVOL_DB + floor(ldBscaled) : 0) / MINVOL_DB * (alsa.mixer_max-alsa.mixer_min)) + alsa.mixer_min;
+            rraw = ((rdBscaled > -MINVOL_DB ? MINVOL_DB + floor(rdBscaled) : 0) / MINVOL_DB * (alsa.mixer_max-alsa.mixer_min)) + alsa.mixer_min;
         }
         LOG_DEBUG("setting vol raw [%ld..%ld]", alsa.mixer_min, alsa.mixer_max);
         if ((err = snd_mixer_selem_set_playback_volume(alsa.mixer_elem, SND_MIXER_SCHN_FRONT_LEFT, lraw)) < 0) {
@@ -203,15 +212,15 @@ static void set_mixer(bool setmax, float ldB, float rdB) {
 		if (setmax) {
 			// set to 0dB if available as this should be max volume for music recored at max pcm values
 			if (alsa.mixer_max >= 0 && alsa.mixer_min <= 0) {
-				ldB = rdB = 0;
+				ldB = rdB = 0 + dBscaling;
 			} else {
-				ldB = rdB = alsa.mixer_max;
+				ldB = rdB = alsa.mixer_max + dBscaling;
 			}
 		}
-		if ((err = snd_mixer_selem_set_playback_dB(alsa.mixer_elem, SND_MIXER_SCHN_FRONT_LEFT, 100 * ldB, 1)) < 0) {
+		if ((err = snd_mixer_selem_set_playback_dB(alsa.mixer_elem, SND_MIXER_SCHN_FRONT_LEFT, 100 * ldBscaled, 1)) < 0) {
 			LOG_ERROR("error setting left volume: %s", snd_strerror(err));
 		}
-		if ((err = snd_mixer_selem_set_playback_dB(alsa.mixer_elem, SND_MIXER_SCHN_FRONT_RIGHT, 100 * rdB, 1)) < 0) {
+		if ((err = snd_mixer_selem_set_playback_dB(alsa.mixer_elem, SND_MIXER_SCHN_FRONT_RIGHT, 100 * rdBscaled, 1)) < 0) {
 			LOG_ERROR("error setting right volume: %s", snd_strerror(err));
 		}
 	}
@@ -223,7 +232,7 @@ static void set_mixer(bool setmax, float ldB, float rdB) {
 		LOG_ERROR("error getting right vol: %s", snd_strerror(err));
 	}
 
-	LOG_DEBUG("%s left: %3.1fdB -> %ld right: %3.1fdB -> %ld", alsa.volume_mixer_name, ldB, nleft, rdB, nright);
+	LOG_DEBUG("%s left: %3.1fdB -> %ld right: %3.1fdB -> %ld", alsa.volume_mixer_name, ldBscaled, nleft, rdBscaled, nright);
 }
 
 void set_volume(unsigned left, unsigned right) {
@@ -911,7 +920,7 @@ int mixer_init_alsa(const char *device, const char *mixer, int mixer_index) {
 
 static pthread_t thread;
 
-void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear) {
+void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, unsigned mixer_scaling) {
 
 	unsigned alsa_buffer = ALSA_BUFFER_TIME;
 	unsigned alsa_period = ALSA_PERIOD_COUNT;
@@ -953,6 +962,7 @@ void output_init_alsa(log_level level, const char *device, unsigned output_buf_s
 	alsa.mixer_ctl = mixer_device ? ctl4device(mixer_device) : alsa.ctl;
 	alsa.volume_mixer_name = volume_mixer_name;
 	alsa.mixer_linear = mixer_linear;
+	alsa.mixer_scaling = mixer_scaling;
 
 	output.format = 0;
 	output.buffer = alsa_buffer;

--- a/output_pa.c
+++ b/output_pa.c
@@ -150,7 +150,7 @@ static int pa_callback(const void *pa_input, void *pa_output, unsigned long pa_f
 static int pa_callback(void *pa_input, void *pa_output, unsigned long pa_frames_wanted, 
 			   PaTimestamp outTime, void *userData);
 #endif
-bool test_open(const char *device, unsigned rates[], bool userdef_rates) {
+bool test_open(const char *device, unsigned rates[]) {
 	PaStreamParameters outputParameters;
 	PaError err;
 	unsigned ref[] TEST_RATES;
@@ -193,9 +193,7 @@ bool test_open(const char *device, unsigned rates[], bool userdef_rates) {
 #endif
 			case paNoError:
 				Pa_CloseStream(pa.stream);
-				if (!userdef_rates) {
-					rates[ind++] = ref[i];
-				}
+				rates[ind++] = ref[i];
 				continue;
 
 			default:	
@@ -205,7 +203,7 @@ bool test_open(const char *device, unsigned rates[], bool userdef_rates) {
 		}
 	}
 
-	if (!rates[0] && !userdef_rates) {
+	if (!rates[0]) {
 		LOG_WARN("no available rate found");
 		return false;
 	}

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -217,6 +217,7 @@
 #define ALSA_BUFFER_TIME  40
 #define ALSA_PERIOD_COUNT 4
 #define OUTPUT_RT_PRIORITY 45
+#define OUTPUT_MIXER_SCALING 100
 #endif
 
 #define SL_LITTLE_ENDIAN (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
@@ -633,7 +634,7 @@ void list_devices(void);
 void list_mixers(const char *output_device);
 void set_volume(unsigned left, unsigned right);
 bool test_open(const char *device, unsigned rates[], bool userdef_rates);
-void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear);
+void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, unsigned mixer_scaling);
 void output_close_alsa(void);
 #endif
 

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -633,13 +633,8 @@ void _checkfade(bool);
 void list_devices(void);
 void list_mixers(const char *output_device);
 void set_volume(unsigned left, unsigned right);
-<<<<<<< HEAD
 bool test_open(const char *device, unsigned rates[], bool userdef_rates);
 void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, unsigned mixer_scaling);
-=======
-bool test_open(const char *device, unsigned rates[]);
-void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear);
->>>>>>> parent of 54f9206... Fix output_thread hang when an invalid output device name and user defined rate(s) are specified.
 void output_close_alsa(void);
 #endif
 

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -633,7 +633,7 @@ void _checkfade(bool);
 void list_devices(void);
 void list_mixers(const char *output_device);
 void set_volume(unsigned left, unsigned right);
-bool test_open(const char *device, unsigned rates[], bool userdef_rates);
+bool test_open(const char *device, unsigned rates[]);
 void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, unsigned mixer_scaling);
 void output_close_alsa(void);
 #endif

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -24,7 +24,7 @@
 
 // make may define: PORTAUDIO, SELFPIPE, RESAMPLE, RESAMPLE_MP, VISEXPORT, GPIO, IR, DSD, LINKALL to influence build
 
-#define VERSION "v1.9.0-1112"
+#define VERSION "v1.9.0-1113"
 
 #if !defined(MODEL_NAME)
 #define MODEL_NAME SqueezeLite
@@ -633,8 +633,13 @@ void _checkfade(bool);
 void list_devices(void);
 void list_mixers(const char *output_device);
 void set_volume(unsigned left, unsigned right);
+<<<<<<< HEAD
 bool test_open(const char *device, unsigned rates[], bool userdef_rates);
 void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, unsigned mixer_scaling);
+=======
+bool test_open(const char *device, unsigned rates[]);
+void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear);
+>>>>>>> parent of 54f9206... Fix output_thread hang when an invalid output device name and user defined rate(s) are specified.
 void output_close_alsa(void);
 #endif
 
@@ -642,7 +647,7 @@ void output_close_alsa(void);
 #if PORTAUDIO
 void list_devices(void);
 void set_volume(unsigned left, unsigned right);
-bool test_open(const char *device, unsigned rates[], bool userdef_rates);
+bool test_open(const char *device, unsigned rates[]);
 void output_init_pa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned idle);
 void output_close_pa(void);
 void _pa_open(void);


### PR DESCRIPTION
…l relative to squeezeserver volume level. 

This seems to work perfectly for me - it scales the mixer output level relative to the squeezeserver volume. However I'm now getting an issue where I get the following error if I restart my M-DAC (eg. the ALSA device disappears and comes back again):

```
[23:07:19.288101] process:514 audg
[23:07:19.288212] process_audg:426 audg gainL: 142 gainR: 142 adjust: 1
[23:07:19.288300] set_mixer:190 Volume scaling factor: 30 -> -26.1dB
[23:07:19.288382] set_mixer:211 setting vol dB [-8000..300]
[23:07:19.288458] set_mixer:221 error setting left volume: No such device
[23:07:19.288532] set_mixer:224 error setting right volume: No such device
[23:07:19.288586] set_mixer:235 PCM left: -79.4dB -> 0 right: -79.4dB -> 0
[23:07:20.001616] process:514 strm
[23:07:20.001753] process_strm:264 strm command t
```

I didn't have this problem with the previous version 1.8.4 which was included with Raspbian. Restarting squeezelite brings everything back to life. Need to do some further testing to check whether this regression is in place without my changes, or whether my changes have introduced the issue.

Dan.