### PR TITLE
add -Y cmd line param to allow scaling of mixer output relative to sq…

### DIFF
--- a/squeezelite.h
+++ b/squeezelite.h
@@ -217,6 +217,7 @@
 #define ALSA_BUFFER_TIME  40
 #define ALSA_PERIOD_COUNT 4
 #define OUTPUT_RT_PRIORITY 45
+#define OUTPUT_MIXER_SCALING 100
 #endif
 
 #define SL_LITTLE_ENDIAN (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
@@ -633,7 +634,7 @@ void list_devices(void);
 void list_mixers(const char *output_device);
 void set_volume(unsigned left, unsigned right);
 bool test_open(const char *device, unsigned rates[], bool userdef_rates);
-void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear);
+void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, unsigned mixer_scaling);
 void output_close_alsa(void);
 #endif
 


### PR DESCRIPTION
…ueezeserver volume

Added a command line parameter to allow the ALSA mixer output to set be controlled as a percentage of the current squeezeserver volume. This allows for scenarios where the mixer device acts as the volume control for a DAC or AMP to avoid damaging speakers with inadvertently high volume settings.

I have applied the patch as requested so hopefully this compiles without ALSA. I think I have also fixed an issue that was preventing the mixer reinitialising correctly after an USB DAC is power cycled (eg. ALSA device disappears and reappears).