### PR TITLE
RPi wiringPi library is depreciated, convert to pigpio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ SOURCES_RESAMPLE = process.c resample.c
 SOURCES_VIS      = output_vis.c
 SOURCES_IR       = ir.c
 SOURCES_GPIO     = gpio.c
+SOURCES_RPI      = minimal_gpio.c
 SOURCES_FAAD     = faad.c
 SOURCES_SSL      = sslsym.c
 SOURCES_OPUS     = opus.c
 
 LINK_LINUX       = -ldl
-LINK_RPI         = -lwiringPi
 LINK_SSL         = -lssl -lcrypto
 LINK_ALAC        = -lalac
 
@@ -75,6 +75,9 @@ ifneq (,$(findstring $(OPT_IR), $(OPTS)))
 endif
 ifneq (,$(findstring $(OPT_GPIO), $(OPTS)))
 	SOURCES += $(SOURCES_GPIO)
+endif
+ifneq (,$(findstring $(OPT_RPI), $(OPTS)))
+	SOURCES += $(SOURCES_RPI)
 endif
 # ensure GPIO is enabled with RPI
 ifneq (,$(findstring $(OPT_RPI), $(OPTS)))
@@ -121,9 +124,6 @@ ifneq (,$(findstring $(OPT_NOSSLSYM), $(OPTS)))
 endif
 endif
 
-ifneq (,$(findstring $(OPT_RPI), $(OPTS)))
-	LDADD += $(LINK_RPI)
-endif
 ifneq (,$(findstring $(OPT_ALAC), $(OPTS)))
 	LDADD += $(LINK_ALAC)
 endif

--- a/README.md
+++ b/README.md
@@ -25,12 +25,8 @@ which is subject to its own license.<br>
 Option to allow server side upsampling for PCM streams (-W) from<br>
 squeezelite-R2 (c) Marco Curti 2015, marcoc1712@gmail.com.<br>
 <br>
-Additions (c) Paul Hermann, 2015, 2017 under the same license terms<br>
-- Launch a script on power status change<br>
-- Control of Raspberry pi GPIO for amplifier power<br>
-<br>
-RaspberryPi wiringpi GPIO Interface library Copyright (c) 2012-2017<br>
-Gordon Henderson, which is subject to its own license.<br>
+RaspberryPi minimal GPIO Interface<br>
+http://abyz.me.uk/rpi/pigpio/examples.html#Misc_minimal_gpio.<br>
 <br>
 This software uses libraries from the FFmpeg project under<br>
 the LGPLv2.1 and its source can be downloaded from<br>

--- a/gpio.c
+++ b/gpio.c
@@ -25,9 +25,6 @@
 #if GPIO
 
 #include "squeezelite.h"
-#ifdef RPI
-#include <wiringPi.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -41,17 +38,20 @@ void relay( int state) {
     gpio_state = state;
 
   // Set up gpio  using BCM Pin #'s
-  if (initialized == -1){
-	wiringPiSetupGpio();
-	initialized = 1;
-	pinMode (gpio_pin, OUTPUT);
-  }
+	if (initialized == -1){
+		if ( gpioInitialise() == 0 ){
+			initialized = 1;
+		}
+	}
+	if ( initialized == 1){
+		gpioSetMode (gpio_pin, PI_OUTPUT);
+	}
 
-    if(gpio_state == 1)
-        digitalWrite(gpio_pin, HIGH^gpio_active_low);
-    else if(gpio_state == 0)
-        digitalWrite(gpio_pin, LOW^gpio_active_low);
-    // Done!
+	if(gpio_state == 1)
+		gpioWrite(gpio_pin, PI_HIGH^gpio_active_low);
+	else if(gpio_state == 0)
+		gpioWrite(gpio_pin, PI_LOW^gpio_active_low);
+  // Done!
 #endif
 }
 

--- a/main.c
+++ b/main.c
@@ -247,14 +247,8 @@ static void license(void) {
 #endif
 		   "\nOption to allow server side upsampling for PCM streams (-W) from\n"
 		   "squeezelite-R2 (c) Marco Curti 2015, marcoc1712@gmail.com.\n"
-#if GPIO
-		   "\nAdditions (c) Paul Hermann, 2015, 2017 under the same license terms\n"
-		   "- Launch a script on power status change\n"
-		   "- Control of Raspberry pi GPIO for amplifier power\n"
-#endif
 #if RPI
-		   "\nContains wiringpi GPIO Interface library Copyright (c) 2012-2017\n"
-		   "Gordon Henderson, which is subject to its own license.\n"
+		   "\nContains minimal GPIO Interface <http://abyz.me.uk/rpi/pigpio/>.\n"
 #endif
 #if FFMPEG
 		   "\nThis software uses libraries from the FFmpeg project under\n"

--- a/minimal_gpio.c
+++ b/minimal_gpio.c
@@ -1,0 +1,281 @@
+/*
+   minimal_gpio.c
+   2019-07-03
+   Public Domain
+
+	Original Site: http://abyz.me.uk/rpi/pigpio/examples.html
+
+*/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+static volatile uint32_t piPeriphBase = 0x20000000;
+
+static volatile int pi_is_2711 = 0;
+
+#define SYST_BASE  (piPeriphBase + 0x003000)
+#define DMA_BASE   (piPeriphBase + 0x007000)
+#define CLK_BASE   (piPeriphBase + 0x101000)
+#define GPIO_BASE  (piPeriphBase + 0x200000)
+#define UART0_BASE (piPeriphBase + 0x201000)
+#define PCM_BASE   (piPeriphBase + 0x203000)
+#define SPI0_BASE  (piPeriphBase + 0x204000)
+#define I2C0_BASE  (piPeriphBase + 0x205000)
+#define PWM_BASE   (piPeriphBase + 0x20C000)
+#define BSCS_BASE  (piPeriphBase + 0x214000)
+#define UART1_BASE (piPeriphBase + 0x215000)
+#define I2C1_BASE  (piPeriphBase + 0x804000)
+#define I2C2_BASE  (piPeriphBase + 0x805000)
+#define DMA15_BASE (piPeriphBase + 0xE05000)
+
+#define DMA_LEN   0x1000 /* allow access to all channels */
+#define CLK_LEN   0xA8
+#define GPIO_LEN  0xF4
+#define SYST_LEN  0x1C
+#define PCM_LEN   0x24
+#define PWM_LEN   0x28
+#define I2C_LEN   0x1C
+#define BSCS_LEN  0x40
+
+#define GPSET0 7
+#define GPSET1 8
+
+#define GPCLR0 10
+#define GPCLR1 11
+
+#define GPLEV0 13
+#define GPLEV1 14
+
+#define GPPUD     37
+#define GPPUDCLK0 38
+#define GPPUDCLK1 39
+
+/* BCM2711 has different pulls */
+
+#define GPPUPPDN0 57
+#define GPPUPPDN1 58
+#define GPPUPPDN2 59
+#define GPPUPPDN3 60
+
+#define SYST_CS  0
+#define SYST_CLO 1
+#define SYST_CHI 2
+
+static volatile uint32_t  *gpioReg = MAP_FAILED;
+static volatile uint32_t  *systReg = MAP_FAILED;
+static volatile uint32_t  *bscsReg = MAP_FAILED;
+
+#define PI_BANK (gpio>>5)
+#define PI_BIT  (1<<(gpio&0x1F))
+
+/* gpio modes. */
+
+#define PI_INPUT  0
+#define PI_OUTPUT 1
+#define PI_ALT0   4
+#define PI_ALT1   5
+#define PI_ALT2   6
+#define PI_ALT3   7
+#define PI_ALT4   3
+#define PI_ALT5   2
+
+void gpioSetMode(unsigned gpio, unsigned mode)
+{
+   int reg, shift;
+
+   reg   =  gpio/10;
+   shift = (gpio%10) * 3;
+
+   gpioReg[reg] = (gpioReg[reg] & ~(7<<shift)) | (mode<<shift);
+}
+
+int gpioGetMode(unsigned gpio)
+{
+   int reg, shift;
+
+   reg   =  gpio/10;
+   shift = (gpio%10) * 3;
+
+   return (*(gpioReg + reg) >> shift) & 7;
+}
+
+/* Values for pull-ups/downs off, pull-down and pull-up. */
+
+#define PI_PUD_OFF  0
+#define PI_PUD_DOWN 1
+#define PI_PUD_UP   2
+
+void gpioSetPullUpDown(unsigned gpio, unsigned pud)
+{
+   int shift = (gpio & 0xf) << 1;
+   uint32_t bits;
+   uint32_t pull;
+
+   if (pi_is_2711)
+   {
+      switch (pud)
+      {
+         case PI_PUD_OFF:  pull = 0; break;
+         case PI_PUD_UP:   pull = 1; break;
+         case PI_PUD_DOWN: pull = 2; break;
+      }
+
+      bits = *(gpioReg + GPPUPPDN0 + (gpio>>4));
+      bits &= ~(3 << shift);
+      bits |= (pull << shift);
+      *(gpioReg + GPPUPPDN0 + (gpio>>4)) = bits;
+   }
+   else
+   {
+      *(gpioReg + GPPUD) = pud;
+
+      usleep(20);
+
+      *(gpioReg + GPPUDCLK0 + PI_BANK) = PI_BIT;
+
+      usleep(20);
+  
+      *(gpioReg + GPPUD) = 0;
+
+      *(gpioReg + GPPUDCLK0 + PI_BANK) = 0;
+   }
+}
+
+int gpioRead(unsigned gpio)
+{
+   if ((*(gpioReg + GPLEV0 + PI_BANK) & PI_BIT) != 0) return 1;
+   else                                         return 0;
+}
+
+void gpioWrite(unsigned gpio, unsigned level)
+{
+   if (level == 0) *(gpioReg + GPCLR0 + PI_BANK) = PI_BIT;
+   else            *(gpioReg + GPSET0 + PI_BANK) = PI_BIT;
+}
+
+void gpioTrigger(unsigned gpio, unsigned pulseLen, unsigned level)
+{
+   if (level == 0) *(gpioReg + GPCLR0 + PI_BANK) = PI_BIT;
+   else            *(gpioReg + GPSET0 + PI_BANK) = PI_BIT;
+
+   usleep(pulseLen);
+
+   if (level != 0) *(gpioReg + GPCLR0 + PI_BANK) = PI_BIT;
+   else            *(gpioReg + GPSET0 + PI_BANK) = PI_BIT;
+}
+
+/* Bit (1<<x) will be set if gpio x is high. */
+
+uint32_t gpioReadBank1(void) { return (*(gpioReg + GPLEV0)); }
+uint32_t gpioReadBank2(void) { return (*(gpioReg + GPLEV1)); }
+
+/* To clear gpio x bit or in (1<<x). */
+
+void gpioClearBank1(uint32_t bits) { *(gpioReg + GPCLR0) = bits; }
+void gpioClearBank2(uint32_t bits) { *(gpioReg + GPCLR1) = bits; }
+
+/* To set gpio x bit or in (1<<x). */
+
+void gpioSetBank1(uint32_t bits) { *(gpioReg + GPSET0) = bits; }
+void gpioSetBank2(uint32_t bits) { *(gpioReg + GPSET1) = bits; }
+
+unsigned gpioHardwareRevision(void)
+{
+   static unsigned rev = 0;
+
+   FILE *filp;
+   char buf[512];
+   char term;
+   int chars=4; /* number of chars in revision string */
+
+   filp = fopen ("/proc/cpuinfo", "r");
+
+   if (filp != NULL)
+   {
+      while (fgets(buf, sizeof(buf), filp) != NULL)
+      {
+         if (!strncasecmp("revision", buf, 8))
+         {
+            if (sscanf(buf+strlen(buf)-(chars+1),
+               "%x%c", &rev, &term) == 2)
+            {
+               if (term != '\n') rev = 0;
+               else rev &= 0xFFFFFF; /* mask out warranty bit */
+            }
+         }
+      }
+
+      fclose(filp);
+   }
+
+   if (filp = fopen("/proc/device-tree/soc/ranges" , "rb"))
+   {
+      if (fread(buf, 1, sizeof(buf), filp) >= 8)
+      {
+         piPeriphBase = buf[4]<<24 | buf[5]<<16 | buf[6]<<8 | buf[7];
+         if (!piPeriphBase)
+            piPeriphBase = buf[8]<<24 | buf[9]<<16 | buf[10]<<8 | buf[11];
+
+         if (piPeriphBase == 0xFE00000) pi_is_2711 = 1;
+      }
+      fclose(filp);
+   }
+
+   return rev;
+}
+
+/* Returns the number of microseconds after system boot. Wraps around
+   after 1 hour 11 minutes 35 seconds.
+*/
+
+uint32_t gpioTick(void) { return systReg[SYST_CLO]; }
+
+
+/* Map in registers. */
+
+static uint32_t * initMapMem(int fd, uint32_t addr, uint32_t len)
+{
+    return (uint32_t *) mmap(0, len,
+       PROT_READ|PROT_WRITE|PROT_EXEC,
+       MAP_SHARED|MAP_LOCKED,
+       fd, addr);
+}
+
+int gpioInitialise(void)
+{
+   int fd;
+
+   gpioHardwareRevision(); /* sets rev and peripherals base address */
+
+   fd = open("/dev/mem", O_RDWR | O_SYNC) ;
+
+   if (fd < 0)
+   {
+      fprintf(stderr,
+         "This program needs root privileges.  Try using sudo\n");
+      return -1;
+   }
+
+   gpioReg  = initMapMem(fd, GPIO_BASE,  GPIO_LEN);
+   systReg  = initMapMem(fd, SYST_BASE,  SYST_LEN);
+   bscsReg  = initMapMem(fd, BSCS_BASE,  BSCS_LEN);
+
+   close(fd);
+
+   if ((gpioReg == MAP_FAILED) ||
+       (systReg == MAP_FAILED) ||
+       (bscsReg == MAP_FAILED))
+   {
+      fprintf(stderr,
+         "Bad, mmap failed\n");
+      return -1;
+   }
+   return 0;
+}

--- a/scripts/buildlnxarmhflinkall
+++ b/scripts/buildlnxarmhflinkall
@@ -1,6 +1,6 @@
 #!/bin/bash
 make -f Makefile.rpi clean
-make -f Makefile.rpi OPTS="-DLINKALL -DFFMPEG -DOPUS -DDSD -DVISEXPORT -DRESAMPLE -DIR -DGPIO -DRPI -DUSE_SSL -I./include -I./include/opus" LDFLAGS="-L./lib -lFLAC -lvorbisfile -lvorbis -logg -lmad -lfaad -lmpg123 -lopusfile -lopus -lavformat -lavcodec -lavutil -lsoxr -llirc_client /usr/lib/gcc/arm-linux-gnueabihf/4.9/libgomp.a /usr/lib/arm-linux-gnueabihf/libssl.a /usr/lib/arm-linux-gnueabihf/libcrypto.a -lwiringPi /usr/lib/arm-linux-gnueabihf/libz.a -lpthread -ldl -lrt -lm -lasound"
+make -f Makefile.rpi OPTS="-DLINKALL -DFFMPEG -DOPUS -DDSD -DVISEXPORT -DRESAMPLE -DIR -DGPIO -DRPI -DUSE_SSL -I./include -I./include/opus" LDFLAGS="-L./lib -lFLAC -lvorbisfile -lvorbis -logg -lmad -lfaad -lmpg123 -lopusfile -lopus -lavformat -lavcodec -lavutil -lsoxr -llirc_client /usr/lib/gcc/arm-linux-gnueabihf/4.9/libgomp.a /usr/lib/arm-linux-gnueabihf/libssl.a /usr/lib/arm-linux-gnueabihf/libcrypto.a /usr/lib/arm-linux-gnueabihf/libz.a -lpthread -ldl -lrt -lm -lasound"
 
 strip squeezelite-rpi
 mv squeezelite-rpi squeezelite

--- a/scripts/buildlnxarmhflinkalldeb7
+++ b/scripts/buildlnxarmhflinkalldeb7
@@ -1,12 +1,12 @@
 #!/bin/bash
 make -f Makefile.rpi clean
-make -f Makefile.rpi OPTS="-DLINKALL -DDSD -DVISEXPORT -DRESAMPLE -DIR -DGPIO -DRPI -I./include" LDFLAGS="/usr/lib/arm-linux-gnueabihf/libFLAC.a /usr/lib/arm-linux-gnueabihf/libvorbisfile.a /usr/lib/arm-linux-gnueabihf/libvorbis.a /usr/lib/arm-linux-gnueabihf/libogg.a /usr/lib/libmad.a /usr/lib/arm-linux-gnueabihf/libfaad.a /usr/lib/arm-linux-gnueabihf/libmpg123.a lib/libsoxr.a /usr/lib/gcc/arm-linux-gnueabihf/4.6/libgomp.a lib/liblirc_client.a lib/libwiringPi.a -lpthread -ldl -lrt -lm -lasound"
+make -f Makefile.rpi OPTS="-DLINKALL -DDSD -DVISEXPORT -DRESAMPLE -DIR -DGPIO -DRPI -I./include" LDFLAGS="/usr/lib/arm-linux-gnueabihf/libFLAC.a /usr/lib/arm-linux-gnueabihf/libvorbisfile.a /usr/lib/arm-linux-gnueabihf/libvorbis.a /usr/lib/arm-linux-gnueabihf/libogg.a /usr/lib/libmad.a /usr/lib/arm-linux-gnueabihf/libfaad.a /usr/lib/arm-linux-gnueabihf/libmpg123.a lib/libsoxr.a /usr/lib/gcc/arm-linux-gnueabihf/4.6/libgomp.a lib/liblirc_client.a -lpthread -ldl -lrt -lm -lasound"
 
 strip squeezelite-rpi
 mv squeezelite-rpi squeezelite-armv6hf-noffmpeg
 
 make -f Makefile.rpi clean
-make -f Makefile.rpi OPTS="-DLINKALL -DFFMPEG -DDSD -DVISEXPORT -DRESAMPLE -DIR -DGPIO -DRPI -I./include" LDFLAGS="/usr/lib/arm-linux-gnueabihf/libFLAC.a /usr/lib/arm-linux-gnueabihf/libvorbisfile.a /usr/lib/arm-linux-gnueabihf/libvorbis.a /usr/lib/arm-linux-gnueabihf/libogg.a /usr/lib/libmad.a /usr/lib/arm-linux-gnueabihf/libfaad.a /usr/lib/arm-linux-gnueabihf/libmpg123.a lib/libswscale.a lib/libavdevice.a lib/libavformat.a lib/libavcodec.a lib/libswresample.a lib/libavutil.a lib/libsoxr.a /usr/lib/gcc/arm-linux-gnueabihf/4.6/libgomp.a lib/liblirc_client.a lib/libwiringPi.a -lpthread -ldl -lrt -lm -lasound"
+make -f Makefile.rpi OPTS="-DLINKALL -DFFMPEG -DDSD -DVISEXPORT -DRESAMPLE -DIR -DGPIO -DRPI -I./include" LDFLAGS="/usr/lib/arm-linux-gnueabihf/libFLAC.a /usr/lib/arm-linux-gnueabihf/libvorbisfile.a /usr/lib/arm-linux-gnueabihf/libvorbis.a /usr/lib/arm-linux-gnueabihf/libogg.a /usr/lib/libmad.a /usr/lib/arm-linux-gnueabihf/libfaad.a /usr/lib/arm-linux-gnueabihf/libmpg123.a lib/libswscale.a lib/libavdevice.a lib/libavformat.a lib/libavcodec.a lib/libswresample.a lib/libavutil.a lib/libsoxr.a /usr/lib/gcc/arm-linux-gnueabihf/4.6/libgomp.a lib/liblirc_client.a -lpthread -ldl -lrt -lm -lasound"
 
 strip squeezelite-rpi
 mv squeezelite-rpi squeezelite-armv6hf-ffmpeg

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -757,6 +757,15 @@ bool gpio_active;
 char *power_script;
 //  my amp state
 int ampstate;
+#if RPI
+#define PI_INPUT  0
+#define PI_OUTPUT 1
+#define PI_LOW 0
+#define PI_HIGH 1
+void gpioSetMode(unsigned gpio, unsigned mode);
+void gpioWrite(unsigned gpio, unsigned level);
+int gpioInitialise(void);
+#endif
 #endif
 
 // ir.c


### PR DESCRIPTION
I think I have all instances of wiringPi removed from the source and build scripts.

