### PR TITLE
Retry with a non-SSL connection if an SSL-connection fails

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -468,14 +468,13 @@ void stream_file(const char *header, size_t header_len, unsigned threshold) {
 	UNLOCK;
 }
 
-void stream_sock(u32_t ip, u16_t port, const char *header, size_t header_len, unsigned threshold, bool cont_wait) {
+static int _tcp_connect(u32_t ip, u16_t port) {
 	struct sockaddr_in addr;
-
 	int sock = socket(AF_INET, SOCK_STREAM, 0);
 
 	if (sock < 0) {
 		LOG_ERROR("failed to create socket");
-		return;
+		return -1;
 	}
 
 	memset(&addr, 0, sizeof(addr));
@@ -490,13 +489,22 @@ void stream_sock(u32_t ip, u16_t port, const char *header, size_t header_len, un
 
 	if (connect_timeout(sock, (struct sockaddr *) &addr, sizeof(addr), 10) < 0) {
 		LOG_INFO("unable to connect to server");
+		closesocket(sock);
+		return -1;
+	}
+	return sock;
+}
+
+void stream_sock(u32_t ip, u16_t port, const char *header, size_t header_len, unsigned threshold, bool cont_wait) {
+	int sock = _tcp_connect(ip, port);
+	if (sock < 0) {
 		LOCK;
 		stream.state = DISCONNECT;
 		stream.disconnect = UNREACHABLE;
 		UNLOCK;
 		return;
 	}
-	
+
 #if USE_SSL
 	if (ntohs(port) == 443) {
 		char *server = strcasestr(header, "Host:");
@@ -513,7 +521,7 @@ void stream_sock(u32_t ip, u16_t port, const char *header, size_t header_len, un
 			SSL_set_tlsext_host_name(ssl, p);
 			free(servername);
 		}
-		
+
 		while (1) {
 			int status, err = 0;
 
@@ -533,15 +541,20 @@ void stream_sock(u32_t ip, u16_t port, const char *header, size_t header_len, un
 			closesocket(sock);
 			SSL_free(ssl);
 			ssl = NULL;
-			LOCK;
-			stream.state = DISCONNECT;
-			stream.disconnect = UNREACHABLE;
-			UNLOCK;
 
-			return;
+			LOG_INFO("Trying non-SSL connection");
+			sock = _tcp_connect(ip, port);
+			if (sock < 0) {
+				LOCK;
+				stream.state = DISCONNECT;
+				stream.disconnect = UNREACHABLE;
+				UNLOCK;
+				return;
+			}
+			break;
 		}
 	} else {
-		ssl = NULL;	
+		ssl = NULL;
 	}
 #endif
 


### PR DESCRIPTION
Some web servers listen for unencrypted traffic on port 443. Establishing
an SSL connection to these servers will fail. Instead of giving up completely,
retry the connection without SSL.

This fixes #76.