### PR TITLE
Fix build failure with GCC 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #Cross compile support - create a Makefile which defines these three variables and then includes this Makefile...
 CFLAGS	?= -Wall -fPIC -O2
+CFLAGS	+= -fcommon
 LDADD	?= -lasound -lpthread -lm -lrt
 EXECUTABLE ?= squeezelite
 


### PR DESCRIPTION
Squeezelite fails to build with GCC 10.  See, e.g., https://koschei.fedoraproject.org/build/7746402 and https://kojipkgs.fedoraproject.org/work/tasks/4697/40814697/build.log.  This is because `-fno-common` is now the default.

This commit sets `-fcommon`, which was the previous default.

However, https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fno-common says, “on many targets [`-fcommon`] implies a speed and code size penalty on global variable references”, so perhaps there’s a better way to do this.