### PR TITLE
Support for PulseAudio properties

### DIFF
--- a/alac.c
+++ b/alac.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #if ALAC
@@ -65,8 +66,6 @@ struct alac {
 };
 
 static struct alac *l;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/decode.c
+++ b/decode.c
@@ -21,9 +21,8 @@
 
 // decode thread
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
-
-log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;
@@ -145,11 +144,9 @@ static void sort_codecs(int pry, struct codec* ptr) {
 
 static thread_type thread;
 
-void decode_init(log_level level, const char *include_codecs, const char *exclude_codecs) {
+void decode_init(const char *include_codecs, const char *exclude_codecs) {
 	int i;
 	char* order_codecs;
-
-	loglevel = level;
 
 	LOG_INFO("init decode");
 

--- a/dsd.c
+++ b/dsd.c
@@ -21,14 +21,13 @@
 
 // dsd support
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #if DSD
 
 // use dsd2pcm from Sebastian Gesemann for conversion to pcm:
 #include "./dsd2pcm/dsd2pcm.h"
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/faad.c
+++ b/faad.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #include <neaacdec.h>
@@ -57,8 +58,6 @@ struct faad {
 };
 
 static struct faad *a;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #if FFMPEG
@@ -93,8 +94,6 @@ struct ff_s {
 };
 
 static struct ff_s *ff;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;
@@ -745,7 +744,7 @@ struct codec *register_ff(const char *codec) {
 			return NULL;
 		}
 
-		switch (loglevel) {
+		switch (LOG_GET_LEVEL()) {
 		case lERROR:
 			ff_log_level = AV_LOG_ERROR; break;
 		case lWARN:

--- a/flac.c
+++ b/flac.c
@@ -18,6 +18,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #include <FLAC/stream_decoder.h>
@@ -61,8 +62,6 @@ struct flac {
 };
 
 static struct flac *f;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/ir.c
+++ b/ir.c
@@ -33,11 +33,10 @@
 #undef LOG_INFO
 #endif
 
+#define LOG_COMPONENT	LOG_COMPONENT_IR
 #include "squeezelite.h"
 
 #define LIRC_CLIENT_ID "squeezelite"
-
-static log_level loglevel;
 
 struct irstate ir;
 
@@ -210,9 +209,7 @@ static bool load_lirc() {
 }
 #endif
 
-void ir_init(log_level level, char *lircrc) {
-	loglevel = level;
-
+void ir_init(char *lircrc) {
 #if !LINKALL
 	i = malloc(sizeof(struct lirc));
 	if (!i || !load_lirc()) {

--- a/mad.c
+++ b/mad.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #include <mad.h>
@@ -55,8 +56,6 @@ struct mad {
 };
 
 static struct mad *m;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/main.c
+++ b/main.c
@@ -310,6 +310,10 @@ static void slimproto_notify_handler(enum notify_event_type e, void *arg) {
 			break;
 		}
 #endif
+
+		// make compiler happy
+		default:
+			break;
 	}
 }
 

--- a/mpg.c
+++ b/mpg.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #include <mpg123.h>
@@ -46,8 +47,6 @@ struct mpg {
 };
 
 static struct mpg *m;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/opus.c
+++ b/opus.c
@@ -20,6 +20,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 /* 
@@ -55,8 +56,6 @@ struct opus {
 };
 
 static struct opus *u;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/output.c
+++ b/output.c
@@ -21,9 +21,8 @@
 
 // Common output function
 
+#define LOG_COMPONENT	LOG_COMPONENT_OUTPUT
 #include "squeezelite.h"
-
-static log_level loglevel;
 
 struct outputstate output;
 
@@ -341,10 +340,8 @@ void _checkfade(bool start) {
 	}
 }
 
-void output_init_common(log_level level, const char *device, unsigned output_buf_size, unsigned rates[], unsigned idle) {
+void output_init_common(const char *device, unsigned output_buf_size, unsigned rates[], unsigned idle) {
 	unsigned i;
-
-	loglevel = level;
 
 	output_buf_size = output_buf_size - (output_buf_size % BYTES_PER_FRAME);
 	LOG_DEBUG("outputbuf size: %u", output_buf_size);
@@ -412,7 +409,7 @@ void output_init_common(log_level level, const char *device, unsigned output_buf
 	
 	output.current_sample_rate = output.default_sample_rate;
 
-	if (loglevel >= lINFO) {
+	if (LOG_LEVEL_IS_ENABLED(lINFO)) {
 		char rates_buf[10 * MAX_SUPPORTED_SAMPLERATES] = "";
 		for (i = 0; output.supported_rates[i]; ++i) {
 			char s[10];

--- a/output_pa.c
+++ b/output_pa.c
@@ -21,6 +21,7 @@
 
 // Portaudio output
 
+#define LOG_COMPONENT	LOG_COMPONENT_OUTPUT
 #include "squeezelite.h"
 
 #if PORTAUDIO
@@ -64,8 +65,6 @@ static struct {
 	unsigned rate;
 	PaStream *stream;
 } pa;
-
-static log_level loglevel;
 
 static bool running = true;
 
@@ -544,7 +543,7 @@ static int pa_callback(void *pa_input, void *pa_output, unsigned long pa_frames_
 	return ret;
 }
 
-void output_init_pa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay,
+void output_init_pa(const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay,
 					unsigned idle) {
 	PaError err;
 #ifndef PA18API
@@ -567,8 +566,6 @@ void output_init_pa(log_level level, const char *device, unsigned output_buf_siz
 	if (t) pa_frames  = atoi(t);
 	if (c) pa_nbufs = atoi(c);
 #endif
-
-	loglevel = level;
 
 	LOG_INFO("init output");
 

--- a/output_pulse.c
+++ b/output_pulse.c
@@ -24,6 +24,7 @@
 
 // Output using PulseAudio
 
+#define LOG_COMPONENT	LOG_COMPONENT_OUTPUT
 #include "squeezelite.h"
 
 #if PULSEAUDIO
@@ -55,8 +56,6 @@ struct pulse {
 };
 
 static struct pulse pulse;
-
-static log_level loglevel;
 
 extern struct outputstate output;
 extern struct buffer *outputbuf;
@@ -277,7 +276,7 @@ static void pulse_set_volume(struct pulse *p, unsigned left, unsigned right) {
 	pa_operation *op = pa_context_set_sink_input_volume(pulse_connection_get_context(&p->conn), sink_input_idx, &volume, NULL, NULL);
 	if (op != NULL) {
 		// This is send and forget operation, dereference it right away.
-		if (loglevel >= lDEBUG) {
+		if (LOG_LEVEL_IS_ENABLED(lDEBUG)) {
 			char s[20];
 			LOG_DEBUG("sink input volume set to %s", pa_cvolume_snprint(s, sizeof(s), &volume));
 		}
@@ -436,9 +435,7 @@ static void * output_thread(void *arg) {
 
 static pthread_t thread;
 
-void output_init_pulse(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned idle) {
-	loglevel = level;
-
+void output_init_pulse(const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned idle) {
 	LOG_INFO("init output");
 
 	output.format = 0;
@@ -461,7 +458,7 @@ void output_init_pulse(log_level level, const char *device, unsigned output_buf_
 		pa_proplist_sets(pulse.proplist, PA_PROP_MEDIA_NAME, "squeezelite");
 	}
 
-	output_init_common(level, device, output_buf_size, rates, idle);
+	output_init_common(device, output_buf_size, rates, idle);
 
 	// start output thread
 	pulse.running = true;

--- a/output_stdout.c
+++ b/output_stdout.c
@@ -21,11 +21,10 @@
 
 // Stdout output
 
+#define LOG_COMPONENT	LOG_COMPONENT_OUTPUT
 #include "squeezelite.h"
 
 #define FRAME_BLOCK MAX_SILENCE_FRAMES
-
-static log_level loglevel;
 
 static bool running = true;
 
@@ -124,9 +123,7 @@ static void *output_thread() {
 
 static thread_type thread;
 
-void output_init_stdout(log_level level, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay) {
-	loglevel = level;
-
+void output_init_stdout(unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay) {
 	LOG_INFO("init output stdout");
 
 	buf = malloc(FRAME_BLOCK * BYTES_PER_FRAME);
@@ -154,7 +151,7 @@ void output_init_stdout(log_level level, unsigned output_buf_size, char *params,
 		rates[0] = 44100;
 	}
 
-	output_init_common(level, "-", output_buf_size, rates, 0);
+	output_init_common("-", output_buf_size, rates, 0);
 
 #if LINUX || OSX || FREEBSD
 	pthread_attr_t attr;

--- a/output_vis.c
+++ b/output_vis.c
@@ -21,6 +21,7 @@
 
 // Export audio samples for visualiser process (16 bit only best endevours)
 
+#define LOG_COMPONENT	LOG_COMPONENT_OUTPUT
 #include "squeezelite.h"
 
 #if VISEXPORT
@@ -56,8 +57,6 @@ static struct vis_t {
 
 static char vis_shm_path[40];
 static int vis_fd = -1;
-
-static log_level loglevel;
 
 // attempt to write audio to vis_mmap but do not wait more than VIS_LOCK_NS to get wrlock
 // this can result in missing audio export to the mmap region, but this is preferable dropping audio
@@ -132,9 +131,7 @@ void vis_stop(void) {
 	}
 }
 
-void output_vis_init(log_level level, u8_t *mac) {
-	loglevel = level;
-
+void output_vis_init(u8_t *mac) {
 	sprintf(vis_shm_path, "/squeezelite-%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
 	mode_t old_mask = umask(000); // allow any user to read our shm when created

--- a/pcm.c
+++ b/pcm.c
@@ -19,9 +19,8 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;

--- a/process.c
+++ b/process.c
@@ -21,11 +21,10 @@
 
 // sample processing - only included when building with PROCESS set
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #if PROCESS
-
-extern log_level loglevel;
 
 extern struct buffer *outputbuf;
 extern struct decodestate decode;

--- a/resample.c
+++ b/resample.c
@@ -21,14 +21,13 @@
 
 // upsampling using libsoxr - only included if RESAMPLE set
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 #if RESAMPLE
 
 #include <math.h>
 #include <soxr.h>
-
-extern log_level loglevel;
 
 struct soxr {
 	soxr_t resampler;

--- a/slimproto.c
+++ b/slimproto.c
@@ -22,10 +22,9 @@
  *   -Launch script on power status change from LMS
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_SLIMPROTO
 #include "squeezelite.h"
 #include "slimproto.h"
-
-static log_level loglevel;
 
 #define SQUEEZENETWORK "mysqueezebox.com:3483"
 
@@ -188,11 +187,9 @@ static void sendSTAT(const char *event, u32_t server_timestamp) {
 
 	LOG_DEBUG("STAT: %s", event);
 
-	if (loglevel == lSDEBUG) {
-		LOG_SDEBUG("received bytesL: %u streambuf: %u outputbuf: %u calc elapsed: %u real elapsed: %u (diff: %d) device: %u delay: %d",
-				   (u32_t)status.stream_bytes, status.stream_full, status.output_full, ms_played, now - status.stream_start,
-				   ms_played - now + status.stream_start, status.device_frames * 1000 / status.current_sample_rate, now - status.updated);
-	}
+	LOG_SDEBUG("received bytesL: %u streambuf: %u outputbuf: %u calc elapsed: %u real elapsed: %u (diff: %d) device: %u delay: %d",
+		   (u32_t)status.stream_bytes, status.stream_full, status.output_full, ms_played, now - status.stream_start,
+		   ms_played - now + status.stream_start, status.device_frames * 1000 / status.current_sample_rate, now - status.updated);
 
 	send_packet((u8_t *)&pkt, sizeof(pkt));
 }
@@ -807,7 +804,7 @@ in_addr_t discover_server(char *default_server) {
 #define FIXED_CAP_LEN 256
 #define VAR_CAP_LEN   128
 
-void slimproto(log_level level, char *server, int maxSampleRate, notify_cb cb) {
+void slimproto(char *server, int maxSampleRate, notify_cb cb) {
 	struct sockaddr_in serv_addr;
 	static char fixed_cap[FIXED_CAP_LEN], var_cap[VAR_CAP_LEN] = "";
 	bool reconnect = false;
@@ -820,7 +817,6 @@ void slimproto(log_level level, char *server, int maxSampleRate, notify_cb cb) {
 
 	wake_create(wake_e);
 
-	loglevel = level;
 	notify = cb;
 	running = true;
 

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -456,6 +456,7 @@ char* strcasestr(const char *haystack, const char *needle);
 
 char *next_param(char *src, char c);
 u32_t gettime_ms(void);
+int parse_mac(const char *s, u8_t *mac);
 void get_mac(u8_t *mac);
 void set_nonblock(sockfd s);
 int connect_timeout(sockfd sock, const struct sockaddr *addr, socklen_t addrlen, int timeout);
@@ -797,3 +798,6 @@ void free_ssl_symbols(void);
 bool ssl_loaded;
 #endif
 
+struct player_info {
+	u8_t mac[6];
+};

--- a/stream.c
+++ b/stream.c
@@ -23,6 +23,7 @@
 
 #define _GNU_SOURCE
 
+#define LOG_COMPONENT	LOG_COMPONENT_STREAM
 #include "squeezelite.h"
 
 #include <fcntl.h>
@@ -35,7 +36,6 @@
 #if SUN
 #include <signal.h>
 #endif
-static log_level loglevel;
 
 static struct buffer buf;
 struct buffer *streambuf = &buf;
@@ -364,9 +364,7 @@ static void *stream_thread() {
 
 static thread_type thread;
 
-void stream_init(log_level level, unsigned stream_buf_size) {
-	loglevel = level;
-
+void stream_init(unsigned stream_buf_size) {
 	LOG_INFO("init stream");
 	LOG_DEBUG("streambuf size: %u", stream_buf_size);
 

--- a/utils.c
+++ b/utils.c
@@ -119,6 +119,23 @@ u32_t gettime_ms(void) {
 #endif
 }
 
+int parse_mac(const char *s, u8_t *mac) {
+	int b[6];
+	if (strlen(s) != 17)
+		return 0;
+	int n = sscanf(s, "%x:%x:%x:%x:%x:%x%*c",
+		&b[0], &b[1], &b[2], &b[3], &b[4], &b[5]);
+	if (n != 6)
+		return 0;
+	for (int i = 0; i < 6; i++) {
+		if (b[i] < 0 || b[i] > 255)
+			return 0;
+	}
+	for (int i = 0; i < 6; i++)
+		mac[i] = (u8_t)b[i];
+	return 1;
+}
+
 // mac address
 #if LINUX && !defined(SUN)
 // search first 4 interfaces returned by IFCONF
@@ -130,18 +147,8 @@ void get_mac(u8_t mac[]) {
 	struct ifreq ifs[4];
 
 	utmac = getenv("UTMAC");
-	if (utmac)
-	{
-		if ( strlen(utmac) == 17 )
-		{
-			if (sscanf(utmac,"%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-				&mac[0],&mac[1],&mac[2],&mac[3],&mac[4],&mac[5]) == 6)
-			{
-				return;
-			}
-		}
-
-	}
+	if (utmac && parse_mac(utmac, mac))
+		return;
 
 	mac[0] = mac[1] = mac[2] = mac[3] = mac[4] = mac[5] = 0;
 
@@ -184,18 +191,8 @@ void get_mac(u8_t mac[]) {
 	int                     status=0;
 
 	utmac = getenv("UTMAC");
-	if (utmac)
-	{
-		if ( strlen(utmac) == 17 )
-		{
-			if (sscanf(utmac,"%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-				&mac[0],&mac[1],&mac[2],&mac[3],&mac[4],&mac[5]) == 6)
-			{
-				return;
-			}
-		}
-
-	}
+	if (utmac && parse_mac(utmac, mac))
+		return;
 
 	mac[0] = mac[1] = mac[2] = mac[3] = mac[4] = mac[5] = 0;
 

--- a/utils.c
+++ b/utils.c
@@ -519,3 +519,44 @@ char *strcasestr(const char *haystack, const char *needle) {
 	return NULL;
 }
 #endif
+
+char * read_player_name(const char *filename, char *playername, size_t maxlen) {
+	char *ret = NULL;
+	FILE *fp = fopen(filename, "r");
+	if (fp) {
+		if (!fgets(playername, maxlen - 1, fp)) {
+			playername[maxlen - 1] = '\0';
+		} else {
+			// strip any \n from fgets response
+			int len = strlen(playername);
+			if (len > 0 && playername[len - 1] == '\n') {
+				playername[len - 1] = '\0';
+			}
+			ret = playername;
+		}
+		fclose(fp);
+	}
+	return ret;
+}
+
+int write_player_name(const char *filename, const char *playername) {
+	FILE *fp = fopen(filename, "w");
+	if (fp) {
+		fputs(playername, fp);
+		fclose(fp);
+		return 1;
+	}
+	return 0;
+}
+
+const char * icy_parse_stream_title(const char *s, size_t *len) {
+	const char *title = strstr(s, "StreamTitle='");
+	if (!title)
+		return NULL;
+	title += 13;
+	const char *end = strchr(title, '\'');
+	if (!end)
+		return NULL;
+	*len = end - title;
+	return title;
+}

--- a/vorbis.c
+++ b/vorbis.c
@@ -19,6 +19,7 @@
  *
  */
 
+#define LOG_COMPONENT	LOG_COMPONENT_DECODE
 #include "squeezelite.h"
 
 /* 
@@ -67,8 +68,6 @@ struct vorbis {
 };
 
 static struct vorbis *v;
-
-extern log_level loglevel;
 
 extern struct buffer *streambuf;
 extern struct buffer *outputbuf;


### PR DESCRIPTION
This PR changes several things (I can split the PR to smaller separate ones if desirable).

## Publish properties for PulseAudio sink inputs

This adds `squeezelite.mac`, `squeezelite.player_name` and `squeezelite.model_name` properties for sink inputs. This allows audio stream lookup based of player MAC address or name (e.g. `pactl list sink-inputs`). This change also adds support for standard PulseAudio property `media.name` which is updated with stream metadata.

Most of these information is stored in newly added global variable `player_info`. It is populated at start with MAC address, player name and model. Updates from the server (player name or media name) are propagated through newly added event callback `notify_cb` which is passed to the *slimproto* layer at inititialization. Events are handled in *main* (`slimproto_notify_handler`) and eventually further propagated to the *output* layer.

## Fix high CPU usage when the player is off

~~There was a bug in the PulseAudio output that caused 100% CPU utilization when the player has been turned off. This bug is now fixed.~~

Merged with commit 9db550b60765ce7deb37c2f2bb6aa2e49e6e9627.

## Logging subsystem refactored

I reworked how events are logged. This previously relied on weird mixture of sometimes static, sometimes extern variables all named `log_level`. Now instead of passing log levels individually to each component at initialization, log levels are centralized and to use traditional logging macros (`LOG_INFO`, `LOG_ERROR` etc.) the appropriate `#define LOG_COMPONENT` must appear before #including *squeezelite.h* (or use explicit logging macros `LOG_INFO_COMPONENT`, `LOG_ERROR_COMPONENT` etc.).