### PR TITLE
Makefile: fix build on linux with -DLINKALL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ OPT_NO_FAAD = -DNO_FAAD
 OPT_SSL	    = -DUSE_SSL
 OPT_NOSSLSYM= -DNO_SSLSYM
 OPT_OPUS    = -DOPUS
+OPT_PORTAUDIO = -DPORTAUDIO
+OPT_PULSEAUDIO = -DPULSEAUDIO
 
 SOURCES = \
 	main.c slimproto.c buffer.c stream.c utils.c \
@@ -36,7 +38,10 @@ SOURCES_FAAD     = faad.c
 SOURCES_SSL      = sslsym.c
 SOURCES_OPUS     = opus.c
 
-LINK_LINUX       = -lasound -ldl
+LINK_LINUX       = -ldl
+LINK_ALSA        = -lasound
+LINK_PORTAUDIO   = -lportaudio
+LINK_PULSEAUDIO  = -lpulse
 LINK_SSL         = -lssl -lcrypto
 LINK_ALAC        = -lalac
 
@@ -114,6 +119,13 @@ ifeq (,$(findstring $(OPT_NO_FAAD), $(OPTS)))
 endif	
 ifneq (,$(findstring $(OPT_SSL), $(OPTS)))
 	LDADD += $(LINK_SSL)
+endif
+ifneq (,$(findstring $(OPT_PULSEAUDIO), $(OPTS)))
+	LDADD += $(LINK_PULSEAUDIO)
+else ifneq (,$(findstring $(OPT_PORTAUDIO), $(OPTS)))
+	LDADD += $(LINK_PORTAUDIO)
+else
+	LDADD += $(LINK_ALSA)
 endif
 else
 # if not LINKALL and linux add LINK_LINUX


### PR DESCRIPTION
Build on linux with -DLINKALL is broken since commit
3ba1df7b498fa52074715afc99138086c13e2e48 because of missing -lasound:

```
/home/fabrice/buildroot/output/per-package/squeezelite/host/bin/mipsel-linux-gcc main.o slimproto.o buffer.o stream.o utils.o output.o output_alsa.o output_pa.o output_stdout.o output_pack.o output_pulse.o decode.o flac.o pcm.o mad.o vorbis.o mpg.o ffmpeg.o  -lpthread -lm -lrt -lmad -lmpg123 -lFLAC -lvorbisfile -lvorbis -logg -lavformat -lavcodec -lavutil -o squeezelite
/home/fabrice/buildroot/output/per-package/squeezelite/host/opt/ext-toolchain/bin/../lib/gcc/mipsel-buildroot-linux-gnu/8.3.0/../../../../mipsel-buildroot-linux-gnu/bin/ld: output_alsa.o: in function `alsa_close':
output_alsa.c:(.text+0xd8): undefined reference to `snd_pcm_close'
```

To fix this build failure, move -lasound from LINK_LINUX to its own
LINK_ALSA variable. Then, link with LINK_ALSA with pulseaudio or
portaudio is not defined.

As a side effect, thanks to this change, the user will be able to use
the same Makefile to enable portaudio or pulseaudio instead of calling
the dedicated Makefile.{pa,pulse}

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>