### PR TITLE
stop properly even when received bytes are not % 4

### DIFF
--- a/pcm.c
+++ b/pcm.c
@@ -204,7 +204,7 @@ static decode_state pcm_decode(void) {
 		out = process.max_in_frames;
 	);
 
-	if ((stream.state <= DISCONNECT && bytes == 0) || (limit && audio_left == 0)) {
+	if ((stream.state <= DISCONNECT && bytes < bytes_per_frame) || (limit && audio_left == 0)) {
 		UNLOCK_O_direct;
 		UNLOCK_S;
 		return DECODE_COMPLETE;


### PR DESCRIPTION
Trying to improve aif management, I realized than when streaming aif files (corner case) when the aif header is not removed, the file size might not be % 4. In that case, we end with an infinite loop in decode. This simple safeguard should also work for wav