### PR TITLE
mad frame sync improvement

### DIFF
--- a/mad.c
+++ b/mad.c
@@ -243,6 +243,8 @@ static decode_state mad_decode(void) {
 		MAD(m, synth_frame, &m->synth, &m->frame);
 
 		if (decode.new_stream) {
+			// seems that mad can use some help in term of sync detection
+			if (m->stream.next_frame[0] != 0xff || (m->stream.next_frame[1] & 0xf0) != 0xf0) continue;
 			LOCK_O;
 			LOG_INFO("setting track_start");
 			output.next_sample_rate = decode_newstream(m->synth.pcm.samplerate, output.supported_rates);


### PR DESCRIPTION
On SqueezeliteESP32 I've been reported a few case of wrong sampling rate on mp3. 

After investigation, I had the same issues on all my squeezelite instances (real or bridges) and that came from a faulty file whicht starts with some random data before the real mp3 *audio* header and unfortunately there is a FFFx sequence that mad wrongly evaluate as a valid header, so it starts the decoding sequence from there, using wrong parameters including sample rate. 

It fails again a few frames later and then re-sync but it's too late unfortunately as "new_stream" has been done. I'm a bit surprised that mad sync detection does not very a few more things but anyway, if this has not been fixed in further mad version, here is a patch that checks that "next" frame is actually starting with FFFx and does not start new_stream if not. 

I assume that issue can happen as well when seeking, so it might be handy and that might as well explain issues I have from time to time with podcasts that go crazy sample rate when seeking