### PR TITLE
Set some PulseAudio metadata

### DIFF
--- a/output_pulse.c
+++ b/output_pulse.c
@@ -129,7 +129,7 @@ static bool pulse_connection_init(pulse_connection *conn) {
 	pa_mainloop_api *api = pa_mainloop_get_api(conn->loop);
 	pa_proplist *proplist = pa_proplist_new();
 	pa_proplist_sets(proplist, PA_PROP_APPLICATION_VERSION, VERSION);
-	conn->ctx = pa_context_new_with_proplist(api, "squeezelite", proplist);
+	conn->ctx = pa_context_new_with_proplist(api, MODEL_NAME_STRING, proplist);
 	pa_proplist_free(proplist);
 
 	conn->readiness = readiness_unknown;
@@ -212,7 +212,7 @@ static bool pulse_stream_create(struct pulse *p) {
 	pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, "music");
 	pa_proplist_sets(proplist, PA_PROP_MEDIA_SOFTWARE, "Logitech Media Server");
 
-	p->stream = pa_stream_new_with_proplist(pulse_connection_get_context(&p->conn), "squeezelite", &p->sample_spec, (const pa_channel_map *)NULL, proplist);
+	p->stream = pa_stream_new_with_proplist(pulse_connection_get_context(&p->conn), "Logitech Media Server stream", &p->sample_spec, (const pa_channel_map *)NULL, proplist);
 	pa_proplist_free(proplist);
 	if (p->stream == NULL)
 		return false;

--- a/output_pulse.c
+++ b/output_pulse.c
@@ -127,7 +127,11 @@ static bool pulse_connection_init(pulse_connection *conn) {
 	
 	conn->loop = pa_mainloop_new();
 	pa_mainloop_api *api = pa_mainloop_get_api(conn->loop);
-	conn->ctx = pa_context_new(api, "squeezelite");
+	pa_proplist *proplist = pa_proplist_new();
+	pa_proplist_sets(proplist, PA_PROP_APPLICATION_VERSION, VERSION);
+	conn->ctx = pa_context_new_with_proplist(api, "squeezelite", proplist);
+	pa_proplist_free(proplist);
+
 	conn->readiness = readiness_unknown;
 
 	bool connected = false;
@@ -200,15 +204,16 @@ static void pulse_stream_success_noop_cb(pa_stream *s, int success, void *userda
 }
 
 static bool pulse_stream_create(struct pulse *p) {
-	char name[500];
-	int c = snprintf(name, sizeof(name) - 1, "squeezelite (%s)", "<playername>");
-	name[c] = '\0';
-
 	p->sample_spec.rate = output.current_sample_rate;
 	p->sample_spec.format = PA_SAMPLE_S32LE; // SqueezeLite internally always uses this format, let PulseAudio deal with eventual resampling.
 	p->sample_spec.channels = 2;
 
-	p->stream = pa_stream_new(pulse_connection_get_context(&p->conn), name, &p->sample_spec, (const pa_channel_map *)NULL);
+	pa_proplist *proplist = pa_proplist_new();
+	pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, "music");
+	pa_proplist_sets(proplist, PA_PROP_MEDIA_SOFTWARE, "Logitech Media Server");
+
+	p->stream = pa_stream_new_with_proplist(pulse_connection_get_context(&p->conn), "squeezelite", &p->sample_spec, (const pa_channel_map *)NULL, proplist);
+	pa_proplist_free(proplist);
 	if (p->stream == NULL)
 		return false;
 


### PR DESCRIPTION
- Pass along the squeezelite version to PulseAudio, and hint that we’ll mostly be playing music.
- Remove the string ` (<playername>)` from the end of `application.name`; it looks like this was intended to hold the actual name of the player, but no-one got around to implementing that.

There’s lots more that could potentially be done with this in future.  For example, as well as putting the player name into `application.name`, we might want to put the LMS server hostname into `media.software`, or even now-playing information into `media.artist`, `media.title`, and `media.filename`.

https://freedesktop.org/software/pulseaudio/doxygen/proplist_8h.html