### PR TITLE
re-use RTMP flag in strm_s to indicate that SSL is required

### DIFF
--- a/slimproto.c
+++ b/slimproto.c
@@ -364,7 +364,7 @@ static void process_strm(u8_t *pkt, int len) {
 				stream_file(header, header_len, strm->threshold * 1024);
 				autostart -= 2;
 			} else {
-				stream_sock(ip, port, header, header_len, strm->threshold * 1024, autostart >= 2);
+				stream_sock(ip, port, strm->flags & 0x20, header, header_len, strm->threshold * 1024, autostart >= 2);
 			}
 			sendSTAT("STMc", 0);
 			sentSTMu = sentSTMo = sentSTMl = false;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -540,7 +540,7 @@ struct streamstate {
 void stream_init(log_level level, unsigned stream_buf_size);
 void stream_close(void);
 void stream_file(const char *header, size_t header_len, unsigned threshold);
-void stream_sock(u32_t ip, u16_t port, const char *header, size_t header_len, unsigned threshold, bool cont_wait);
+void stream_sock(u32_t ip, u16_t port, bool use_ssl, const char *header, size_t header_len, unsigned threshold, bool cont_wait);
 bool stream_disconnect(void);
 
 // decode.c


### PR DESCRIPTION
I've tested that change (quickly) on my bridges and that seems to work with current & update LMS version (https://github.com/Logitech/slimserver/pull/454). This more FYI at the moment, it depends as well what @mherger thinks about that other PR