### PR TITLE
Fix memory leak with libmad

### DIFF
--- a/mad.c
+++ b/mad.c
@@ -347,6 +347,12 @@ static void mad_open(u8_t size, u8_t rate, u8_t chan, u8_t endianness) {
 	m->samples = 0;
 	m->readbuf_len = 0;
 	m->last_error = MAD_ERROR_NONE;
+
+	// explicitly clear before calling mad_*_init (again) to free the malloc'd memory
+	MAD(m, stream_finish, &m->stream);
+	MAD(m, frame_finish, &m->frame);
+	mad_synth_finish(&m->synth);
+
 	MAD(m, stream_init, &m->stream);
 	MAD(m, frame_init, &m->frame);
 	MAD(m, synth_init, &m->synth);
@@ -402,7 +408,7 @@ struct codec *register_mad(void) {
 		mad_decode,   // decode
 	};
 
-	m = malloc(sizeof(struct mad));
+	m = calloc(1, sizeof(struct mad));
 	if (!m) {
 		return NULL;
 	}


### PR DESCRIPTION
Members of the mad_stream and mad_frame structs have dynamically
allocated memory. This is only freed by calling mad_*_finish().

If multiple mp3 tracks are played in sequence, decode_close(),
mad_close(), and subsequently, the mad_*_finish() functions are never
called.

So, call the finish functions in mad_open().

To avoid a potential double-free condition, explicitly initialize
the structs to 0 in register_mad() by using calloc() instead of
malloc().