### PR TITLE
Reset PulseAudio sample rate when playing a new track

### DIFF
--- a/output.c
+++ b/output.c
@@ -127,6 +127,9 @@ frames_t _output_frames(frames_t avail) {
 				unsigned delay = 0;
 				if (output.current_sample_rate != output.next_sample_rate) {
 					delay = output.rate_delay;
+# if PULSEAUDIO
+					set_sample_rate(output.next_sample_rate);
+# endif
 				}
 				IF_DSD(
 				   if (output.outfmt != output.next_fmt) {

--- a/output_pulse.c
+++ b/output_pulse.c
@@ -222,9 +222,9 @@ static bool pulse_stream_create(struct pulse *p) {
 
 	if (pa_stream_connect_playback(p->stream, p->sink_name, (const pa_buffer_attr *)NULL,
 #if PULSEAUDIO_TIMING == 2
-		PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING,
+		PA_STREAM_VARIABLE_RATE | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING,
 #else
-	 	PA_STREAM_NOFLAGS,
+		PA_STREAM_VARIABLE_RATE,
 #endif
 		(const pa_cvolume *)NULL, (pa_stream *)NULL) < 0) {
 		pa_stream_unref(p->stream);
@@ -327,6 +327,19 @@ void set_volume(unsigned left, unsigned right) {
 
 	if (adjust_sink_input && pulse.stream != NULL) {
 		pulse_set_volume(&pulse, left, right);
+	}
+}
+
+void set_sample_rate(uint32_t sample_rate) {
+	pa_operation *op = pa_stream_update_sample_rate(pulse.stream, sample_rate, NULL, NULL);
+	if (op != NULL) {
+		if (loglevel >= lDEBUG) {
+			LOG_DEBUG("stream sample rate set to %d Hz", sample_rate);
+		}
+		pa_operation_unref(op);
+	}
+	else {
+		LOG_WARN("failed to set stream sample rate to %d Hz", sample_rate);
 	}
 }
 

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -705,6 +705,7 @@ void _pa_open(void);
 #if PULSEAUDIO
 void list_devices(void);
 void set_volume(unsigned left, unsigned right);
+void set_sample_rate(uint32_t sample_rate);
 bool test_open(const char *device, unsigned rates[], bool userdef_rates);
 void output_init_pulse(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned idle);
 void output_close_pulse(void);


### PR DESCRIPTION
Let PulseAudio know the sample rate detected by the decoder.  It will then perform any required resampling for us.

Fixes #115.