### PR TITLE
SNI parsing w/o leading space and trailing garbage

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -563,7 +563,10 @@ void stream_sock(u32_t ip, u16_t port, bool use_ssl, const char *header, size_t 
 
 	*host = '\0';
 	p = strcasestr(header,"Host:");
-	if (p) sscanf(p, "Host:%255[^:]", host);
+	if (p) {
+		sscanf(p, "Host:%255s", host);
+		if ((p = strchr(host, ':')) != NULL) *p = '\0';
+	}	
 
 	port = ntohs(port);
 	sock = connect_socket(use_ssl || port == 443);


### PR DESCRIPTION
sscanf often bites me ...

The long explanation is that %s removes leading spaces and not [^:] and in addition, now that we know that Host: header shall not contain port when they are defaults, then there is not always a port set by LMS, so we need to handle that correctly. I'll do a more generic sscanf with %s then so that we remove leading spaces and stop on \r\n and then "manually" remove the optional ':' of the port

