### PR TITLE
handle stream_s flags for mono channel

### DIFF
--- a/output.c
+++ b/output.c
@@ -257,8 +257,11 @@ frames_t _output_frames(frames_t avail) {
 		
 		out_frames = !silence ? min(size, cont_frames) : size;
 		
-		if (output.channels & 0x01) gainR = COPY_MONO;
-		else if (output.channels & 0x02) gainL = COPY_MONO;
+		IF_DSD( if (output.outfmt == PCM) )
+		{
+			if (output.channels & 0x01) gainR = COPY_MONO;
+			else if (output.channels & 0x02) gainL = COPY_MONO;
+		}	
 
 		wrote = output.write_cb(out_frames, silence, gainL, gainR, cross_gain_in, cross_gain_out, &cross_ptr);
 

--- a/output.c
+++ b/output.c
@@ -256,6 +256,9 @@ frames_t _output_frames(frames_t avail) {
 		}
 		
 		out_frames = !silence ? min(size, cont_frames) : size;
+		
+		if (output.channels & 0x01) gainR = COPY_MONO;
+		else if (output.channels & 0x02) gainL = COPY_MONO;
 
 		wrote = output.write_cb(out_frames, silence, gainL, gainR, cross_gain_in, cross_gain_out, &cross_ptr);
 

--- a/output_pack.c
+++ b/output_pack.c
@@ -354,12 +354,26 @@ void _apply_cross(struct buffer *outputbuf, frames_t out_frames, s32_t cross_gai
 inline 
 #endif
 void _apply_gain(struct buffer *outputbuf, frames_t count, s32_t gainL, s32_t gainR) {
-	s32_t *ptrL = (s32_t *)(void *)outputbuf->readp;
-	s32_t *ptrR = (s32_t *)(void *)outputbuf->readp + 1;
-	while (count--) {
-		*ptrL = gain(gainL, *ptrL);
-		*ptrR = gain(gainR, *ptrR);
-		ptrL += 2;
-		ptrR += 2;
-	}
+	if (gainL == COPY_MONO) {
+		ISAMPLE_T *ptr = (ISAMPLE_T *)(void *)outputbuf->readp + 1;
+		while (count--) {
+			*(ptr - 1) = *ptr = gain(gainR, *ptr);
+			ptr += 2;
+		}
+	} else if (gainR == COPY_MONO) {
+		ISAMPLE_T *ptr = (ISAMPLE_T *)(void *)outputbuf->readp;
+		while (count--) {
+			*(ptr + 1) = *ptr = gain(gainL, *ptr);
+			ptr += 2;
+		}
+   } else {
+   		ISAMPLE_T *ptrL = (ISAMPLE_T *)(void *)outputbuf->readp;
+		ISAMPLE_T *ptrR = (ISAMPLE_T *)(void *)outputbuf->readp + 1;
+		while (count--) {
+			*ptrL = gain(gainL, *ptrL);
+			*ptrR = gain(gainR, *ptrR);
+			ptrL += 2; ptrR += 2;
+		}
+   }	
 }
+

--- a/output_pack.c
+++ b/output_pack.c
@@ -44,6 +44,23 @@ s32_t to_gain(float f) {
 }
 
 void _scale_and_pack_frames(void *outputptr, s32_t *inputptr, frames_t cnt, s32_t gainL, s32_t gainR, output_format format) {
+	// in-place copy input samples if mono is used (never happens with DSD active)
+	if (gainL == COPY_MONO) {
+		s32_t *ptr = inputptr + 1;
+		frames_t count = cnt;
+		while (count--) {
+			*(ptr - 1) = *ptr;
+			ptr += 2;
+		}
+	} else if (gainR == COPY_MONO) {
+		s32_t *ptr = inputptr;
+		frames_t count = cnt;
+		while (count--) {
+			*(ptr + 1) = *ptr;
+			ptr += 2;
+		}
+   }
+   
 	switch(format) {
 #if DSD
 	case U32_LE:
@@ -376,4 +393,3 @@ void _apply_gain(struct buffer *outputbuf, frames_t count, s32_t gainL, s32_t ga
 		}
    }	
 }
-

--- a/slimproto.c
+++ b/slimproto.c
@@ -380,7 +380,8 @@ static void process_strm(u8_t *pkt, int len) {
 			output.fade_mode = strm->transition_type - '0';
 			output.fade_secs = strm->transition_period;
 			output.invert    = (strm->flags & 0x03) == 0x03;
-			LOG_DEBUG("set fade mode: %u", output.fade_mode);
+			output.channels  = (strm->flags & 0x0c) >> 2;
+			LOG_DEBUG("set fade: %u, channels: %u, invert: %u", output.fade_mode, output.channels, output.invert);
 			UNLOCK_O;
 		}
 		break;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -424,7 +424,8 @@ struct wake {
 
 #define MAX_SILENCE_FRAMES 2048
 
-#define FIXED_ONE 0x10000
+#define FIXED_ONE 	0x10000
+#define COPY_MONO	(FIXED_ONE + 1)
 
 #define BYTES_PER_FRAME 8
 
@@ -621,7 +622,8 @@ typedef enum { FADE_NONE = 0, FADE_CROSSFADE, FADE_IN, FADE_OUT, FADE_INOUT } fa
 struct outputstate {
 	output_state state;
 	output_format format;
-	const char *device;
+	u8_t channels;
+	const char *device;	
 #if ALSA
 	unsigned buffer;
 	unsigned period;


### PR DESCRIPTION
This PR is not to be used as such, it's just to open the discussion

Squeezelite does not handle the slimproto flags in stream_s that requires only one channel to be played. I've changed that on squeezelite-esp32 so that users can create speaker pairs without changing wiring (NB: wiring just one speaker works of course on squeezelite as of today, but it means the same setup cannot be repurposed to either mono or stereo).

LMS only sends this flag when the player is synchronized, otherwise stereo is always forced

This PR works fine (TBC) as long as *_apply_gain* is used to scale samples. L or R is copied if needed by using a special value of *gainR* or *gainL*. Now, the function *_scale_and_pack_frames* is called insted of *_apply_gain* when the audio backend is stdout or alsa with mmap. That function is already humoungous and if I add the case of mono left and right, it will the ugliest thing ever. Now, stdout does not really need it as synchronization does not make sense, so it only leave the case of alsa mmap. 

I can shuffle the problem by adding another sample manipulation function that will duplicate L or R channel in outputbuf prior to gain or pack (taking into account DSD ... stuff), but it will be yet another loop on all samples that hurts my optimization feelings. Any suggestion? 