### PR TITLE
opus & vorbis fix in 32 bits with FRAME_BUF

### DIFF
--- a/opus.c
+++ b/opus.c
@@ -189,7 +189,12 @@ static decode_state opus_decompress(void) {
 
 		// work backward to unpack samples (if needed)
 		iptr = (s16_t *) write_buf + count;
-		optr = (ISAMPLE_T *) write_buf + frames * 2;
+		IF_DIRECT(
+			optr = (ISAMPLE_T *) outputbuf->writep + frames * 2;
+		)
+		IF_PROCESS(
+			optr = (ISAMPLE_T *) write_buf + frames * 2;
+		)
 		
 		if (channels == 2) {
 #if BYTES_PER_FRAME == 4

--- a/vorbis.c
+++ b/vorbis.c
@@ -236,7 +236,12 @@ static decode_state vorbis_decode(void) {
 
 		// work backward to unpack samples (if needed)
 		iptr = (s16_t *) write_buf + count;
-		optr = (ISAMPLE_T *) write_buf + frames * 2;
+		IF_DIRECT(
+			optr = (ISAMPLE_T *) outputbuf->writep + frames * 2;
+		)
+		IF_PROCESS(
+			optr = (ISAMPLE_T *) write_buf + frames * 2;
+		)
 
 		if (channels == 2) {
 #if BYTES_PER_FRAME == 4


### PR DESCRIPTION
There was remaining issues in 32 bits mode when using FRAME_BUF with buffer where results are stored. It did not affect any of your builds, so you can ignore this but I thought I would submit it as you have integrated the 16/32 bits and FRAME_BUF patches. 

Writing too fast and too many permutation and combination to test...