### PR TITLE
Fix polarity inversion with channels

### DIFF
--- a/output.c
+++ b/output.c
@@ -47,6 +47,7 @@ frames_t _output_frames(frames_t avail) {
 
 	frames_t frames, size;
 	bool silence;
+	u8_t flags = output.channels;
 	
 	s32_t cross_gain_in = 0, cross_gain_out = 0; s32_t *cross_ptr = NULL;
 	
@@ -256,17 +257,14 @@ frames_t _output_frames(frames_t avail) {
 		}
 		
 		out_frames = !silence ? min(size, cont_frames) : size;
+		
+		IF_DSD(
+			if (output.outfmt != PCM) {
+				flags = 0;
+			}
+		)
 
-#if DSD
-		if (output.outfmt == PCM)
-		{
-#endif
-			if (output.channels & 0x01) gainR |= MONO_FLAG;
-			if (output.channels & 0x02) gainL |= MONO_FLAG;
-#if DSD
-		}
-#endif
-		wrote = output.write_cb(out_frames, silence, gainL, gainR, cross_gain_in, cross_gain_out, &cross_ptr);
+		wrote = output.write_cb(out_frames, silence, gainL, gainR, flags, cross_gain_in, cross_gain_out, &cross_ptr);
 
 		if (wrote <= 0) {
 			frames -= size;

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -547,7 +547,7 @@ static int alsa_open(const char *device, unsigned sample_rate, unsigned alsa_buf
 	return 0;
 }
 
-static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR,
+static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR, u8_t flags,
 						 s32_t cross_gain_in, s32_t cross_gain_out, s32_t **cross_ptr) {
 
 	const snd_pcm_channel_area_t *areas;
@@ -594,17 +594,14 @@ static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t g
 
 		outputptr = alsa.mmap ? (areas[0].addr + (areas[0].first + offset * areas[0].step) / 8) : alsa.write_buf;
 
-		_scale_and_pack_frames(outputptr, inputptr, out_frames, gainL, gainR, output.format);
+		_scale_and_pack_frames(outputptr, inputptr, out_frames, gainL, gainR, flags, output.format);
 
 	} else {
 
 		outputptr = (void *)inputptr;
 
 		if (!silence) {
-
-			if (gainL != FIXED_ONE || gainR!= FIXED_ONE) {
-				_apply_gain(outputbuf, out_frames, gainL, gainR);
-			}
+			_apply_gain(outputbuf, out_frames, gainL, gainR, flags);
 		}
 	}
 

--- a/output_pa.c
+++ b/output_pa.c
@@ -448,7 +448,7 @@ void _pa_open(void) {
 
 static u8_t *optr;
 
-static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR,
+static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR, u8_t flags,
 						 s32_t cross_gain_in, s32_t cross_gain_out, s32_t **cross_ptr) {
 	
 	if (!silence) {
@@ -458,7 +458,7 @@ static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t g
 		}
 		
 		if (gainL != FIXED_ONE || gainR!= FIXED_ONE) {
-			_apply_gain(outputbuf, out_frames, gainL, gainR);
+			_apply_gain(outputbuf, out_frames, gainL, gainR, flags);
 		}
 
 		IF_DSD(

--- a/output_pack.c
+++ b/output_pack.c
@@ -43,35 +43,32 @@ s32_t to_gain(float f) {
 	return (s32_t)(f * 65536.0F);
 }
 
-void _scale_and_pack_frames(void *outputptr, s32_t *inputptr, frames_t cnt, s32_t gainL, s32_t gainR, output_format format) {
+void _scale_and_pack_frames(void *outputptr, s32_t *inputptr, frames_t cnt, s32_t gainL, s32_t gainR, u8_t flags, output_format format) {
 	// in-place copy input samples if mono/combined is used (never happens with DSD active)
-	if ((gainR & MONO_FLAG) && (gainL & MONO_FLAG)) {
+	if ((flags & MONO_LEFT) && (flags & MONO_RIGHT)) {
 		s32_t *ptr = inputptr;
 		frames_t count = cnt;
-		gainL &= ~MONO_FLAG; gainR &= ~MONO_FLAG;
 		while (count--) {
 			// use 64 bits integer for purists but should really not care
-			*ptr = *(ptr + 1) = ((s64_t) *ptr  + (s64_t) *(ptr + 1)) / 2;
+			*ptr = *(ptr + 1) = ((s64_t) *ptr + (s64_t) *(ptr + 1)) / 2;
 			ptr += 2;
 		}
-	} else if (gainL & MONO_FLAG) {
+	} else if (flags & MONO_RIGHT) {
 		s32_t *ptr = inputptr + 1;
 		frames_t count = cnt;
-		gainL &= ~MONO_FLAG;
 		while (count--) {
 			*(ptr - 1) = *ptr;
 			ptr += 2;
 		}
-	} else if (gainR & MONO_FLAG) {
+	} else if (flags & MONO_LEFT) {	
 		s32_t *ptr = inputptr;
 		frames_t count = cnt;
-		gainR &= ~MONO_FLAG;
 		while (count--) {
 			*(ptr + 1) = *ptr;
 			ptr += 2;
 		}
-   }
-
+	}	
+	
 	switch(format) {
 #if DSD
 	case U32_LE:
@@ -381,34 +378,36 @@ void _apply_cross(struct buffer *outputbuf, frames_t out_frames, s32_t cross_gai
 #if !WIN
 inline 
 #endif
-void _apply_gain(struct buffer *outputbuf, frames_t count, s32_t gainL, s32_t gainR) {
-	if ((gainR & MONO_FLAG) && (gainL & MONO_FLAG)) {
+void _apply_gain(struct buffer *outputbuf, frames_t count, s32_t gainL, s32_t gainR, u8_t flags) {
+	if (gainL == FIXED_ONE && gainR == FIXED_ONE && !(flags & (MONO_LEFT | MONO_RIGHT))) {
+		return;
+	} else if ((flags & MONO_LEFT) && (flags & MONO_RIGHT)) {
 		ISAMPLE_T *ptrL = (ISAMPLE_T *)(void *)outputbuf->readp;
 		ISAMPLE_T *ptrR = (ISAMPLE_T *)(void *)outputbuf->readp + 1;
-		gainL &= ~MONO_FLAG; gainR &= ~MONO_FLAG;
 		while (count--) {
 			*ptrL = *ptrR = (gain(gainL, *ptrL) + gain(gainR, *ptrR)) / 2;
 			ptrL += 2; ptrR += 2;
 		}
-	} else if (gainL & MONO_FLAG) {
+
+	} else if (flags & MONO_RIGHT) {
 		ISAMPLE_T *ptr = (ISAMPLE_T *)(void *)outputbuf->readp + 1;
 		while (count--) {
 			*(ptr - 1) = *ptr = gain(gainR, *ptr);
 			ptr += 2;
 		}
-	} else if (gainR & MONO_FLAG) {
+	} else if (flags & MONO_LEFT) {
 		ISAMPLE_T *ptr = (ISAMPLE_T *)(void *)outputbuf->readp;
 		while (count--) {
 			*(ptr + 1) = *ptr = gain(gainL, *ptr);
 			ptr += 2;
 		}
-   } else {
-   		ISAMPLE_T *ptrL = (ISAMPLE_T *)(void *)outputbuf->readp;
+	} else {
+	   	ISAMPLE_T *ptrL = (ISAMPLE_T *)(void *)outputbuf->readp;
 		ISAMPLE_T *ptrR = (ISAMPLE_T *)(void *)outputbuf->readp + 1;
 		while (count--) {
 			*ptrL = gain(gainL, *ptrL);
 			*ptrR = gain(gainR, *ptrR);
 			ptrL += 2; ptrR += 2;
 		}
-   }
+	}
 }

--- a/output_stdout.c
+++ b/output_stdout.c
@@ -45,7 +45,7 @@ static u8_t *buf;
 static unsigned buffill;
 static int bytes_per_frame;
 
-static int _stdout_write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR,
+static int _stdout_write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR, u8_t flags,
 								s32_t cross_gain_in, s32_t cross_gain_out, s32_t **cross_ptr) {
 
 	u8_t *obuf;
@@ -75,7 +75,7 @@ static int _stdout_write_frames(frames_t out_frames, bool silence, s32_t gainL, 
 		   }
 	)
 
-	_scale_and_pack_frames(buf + buffill * bytes_per_frame, (s32_t *)(void *)obuf, out_frames, gainL, gainR, output.format);
+	_scale_and_pack_frames(buf + buffill * bytes_per_frame, (s32_t *)(void *)obuf, out_frames, gainL, gainR, flags, output.format);
 
 	buffill += out_frames;
 

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -424,8 +424,7 @@ struct wake {
 
 #define MAX_SILENCE_FRAMES 2048
 
-#define FIXED_ONE 0x10000
-#define MONO_FLAG 0x20000
+#define FIXED_ONE 	0x10000
 
 #define BYTES_PER_FRAME 8
 
@@ -616,6 +615,8 @@ typedef enum { FADE_INACTIVE = 0, FADE_DUE, FADE_ACTIVE } fade_state;
 typedef enum { FADE_UP = 1, FADE_DOWN, FADE_CROSS } fade_dir;
 typedef enum { FADE_NONE = 0, FADE_CROSSFADE, FADE_IN, FADE_OUT, FADE_INOUT } fade_mode;
 
+#define MONO_RIGHT	0x02
+#define MONO_LEFT	0x01
 #define MAX_SUPPORTED_SAMPLERATES 18
 #define TEST_RATES = { 768000, 705600, 384000, 352800, 192000, 176400, 96000, 88200, 48000, 44100, 32000, 24000, 22500, 16000, 12000, 11025, 8000, 0 }
 
@@ -634,7 +635,7 @@ struct outputstate {
 	unsigned latency;
 	int pa_hostapi_option;
 #endif
-	int (* write_cb)(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR, s32_t cross_gain_in, s32_t cross_gain_out, s32_t **cross_ptr);
+	int (* write_cb)(frames_t out_frames, bool silence, s32_t gainL, s32_t gainR, u8_t flags, s32_t cross_gain_in, s32_t cross_gain_out, s32_t **cross_ptr);
 	unsigned start_frames;
 	unsigned frames_played;
 	unsigned frames_played_dmp;// frames played at the point delay is measured
@@ -718,9 +719,9 @@ void output_init_stdout(log_level level, unsigned output_buf_size, char *params,
 void output_close_stdout(void);
 
 // output_pack.c
-void _scale_and_pack_frames(void *outputptr, s32_t *inputptr, frames_t cnt, s32_t gainL, s32_t gainR, output_format format);
+void _scale_and_pack_frames(void *outputptr, s32_t *inputptr, frames_t cnt, s32_t gainL, s32_t gainR, u8_t flags, output_format format);
 void _apply_cross(struct buffer *outputbuf, frames_t out_frames, s32_t cross_gain_in, s32_t cross_gain_out, s32_t **cross_ptr);
-void _apply_gain(struct buffer *outputbuf, frames_t count, s32_t gainL, s32_t gainR);
+void _apply_gain(struct buffer *outputbuf, frames_t count, s32_t gainL, s32_t gainR, u8_t flags);
 s32_t gain(s32_t gain, s32_t sample);
 s32_t to_gain(float f);
 


### PR DESCRIPTION
Unfortunately, I again left something with channel management when polarity is inverted, and that's pretty bad because volume is then set at max. This is an urgency correction, I've tested it more on esp32 and I hope it's fine on the main version.

It requires more change than I wanted to do with this channel management because I forgot that gain is signed (polarity inversion) so a flag in the upper 15 bits was not a good idea and rather than trying to continue that direction and play with sign extension, I'd rather explicitly pass the channels flags to the gain functions, leaving gain untouched