### PR TITLE
Support the maximum sample rate allowed by PulseAudio

### DIFF
--- a/output_pulse.c
+++ b/output_pulse.c
@@ -362,8 +362,9 @@ static void pulse_sinkinfo_cb(pa_context *c, const pa_sink_info *l, int eol, voi
 		d->default_sink_name = strdup(l->name);
 
 	if (!d->userdef_rates) {
-		d->rates[0] = l->sample_spec.rate;
+		d->rates[0] = PA_RATE_MAX;
 	}
+	output.default_sample_rate = l->sample_spec.rate;
 
 	*d->sample_spec = l->sample_spec;
 }


### PR DESCRIPTION
Treat the sample rate reported to us by PulseAudio as a default rather than a maximum.

Fixes #140.