### PR TITLE
Reduce CPU usage during FLAC playback

### DIFF
--- a/flac.c
+++ b/flac.c
@@ -123,6 +123,10 @@ static FLAC__StreamDecoderReadStatus read_cb(const FLAC__StreamDecoder *decoder,
 
 	*want = bytes;
 
+	// if there's nothing in the stream buffer, libFLAC will continuously call this function as quickly as possible. slow it down.
+	if (!bytes && !end)
+		usleep(1000);
+
 	return end ? FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM : FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
 }
 


### PR DESCRIPTION
The FLAC decoder will call read_cb() as quickly as possible until it
gets the data it needs to continue decoding, even if the callback is
returning 0 bytes.

Add a 1000us delay in read_cb if it's entered when no data is in the
stream buffer.

With this change, CPU usage drops from 100% to about 15% during playback
of an ogg/flac stream.

Note that the issue seems to be most prominent when using a larger than
default output buffer size - -b :16384 was enough to trigger it in
testing.