### PR TITLE
alpine/libalac/APKBUILD: add libtool makedepend

### DIFF
--- a/alpine/libalac/APKBUILD
+++ b/alpine/libalac/APKBUILD
@@ -7,7 +7,7 @@ url="https://github.com/TimothyGu/alac"
 arch="all"
 subpackages="$pkgname-doc $pkgname-dev"
 license="Apache 2.0"
-makedepends="git autoconf automake make tar"
+makedepends="git autoconf automake libtool make tar"
 source="fix-arm-segfault.patch \
 	alac-version.patch"
 


### PR DESCRIPTION
On Alpine Linux, libalac will not build without libtool. This may have not been noticed before because users building it already had libtool installed, which is common in dev environments.