### PR TITLE
Make it possible to disable mp3 decoder(s) at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,26 +5,28 @@ LDADD	?= -lpthread -lm -lrt
 EXECUTABLE ?= squeezelite
 
 # passing one or more of these in $(OPTS) enables optional feature inclusion
-OPT_DSD     = -DDSD
-OPT_FF      = -DFFMPEG
-OPT_ALAC    = -DALAC
-OPT_LINKALL = -DLINKALL
-OPT_RESAMPLE= -DRESAMPLE
-OPT_VIS     = -DVISEXPORT
-OPT_IR      = -DIR
-OPT_GPIO    = -DGPIO
-OPT_RPI     = -DRPI
-OPT_NO_FAAD = -DNO_FAAD
-OPT_SSL	    = -DUSE_SSL
-OPT_NOSSLSYM= -DNO_SSLSYM
-OPT_OPUS    = -DOPUS
-OPT_PORTAUDIO = -DPORTAUDIO
+OPT_DSD        = -DDSD
+OPT_FF         = -DFFMPEG
+OPT_ALAC       = -DALAC
+OPT_LINKALL    = -DLINKALL
+OPT_RESAMPLE   = -DRESAMPLE
+OPT_VIS        = -DVISEXPORT
+OPT_IR         = -DIR
+OPT_GPIO       = -DGPIO
+OPT_RPI        = -DRPI
+OPT_NO_FAAD    = -DNO_FAAD
+OPT_NO_MAD     = -DNO_MAD
+OPT_NO_MPG123  = -DNO_MPG123
+OPT_SSL        = -DUSE_SSL
+OPT_NOSSLSYM   = -DNO_SSLSYM
+OPT_OPUS       = -DOPUS
+OPT_PORTAUDIO  = -DPORTAUDIO
 OPT_PULSEAUDIO = -DPULSEAUDIO
 
 SOURCES = \
 	main.c slimproto.c buffer.c stream.c utils.c \
 	output.c output_alsa.c output_pa.c output_stdout.c output_pack.c output_pulse.c decode.c \
-	flac.c pcm.c mad.c vorbis.c mpg.c
+	flac.c pcm.c vorbis.c
 
 SOURCES_DSD      = dsd.c dop.c dsd2pcm/dsd2pcm.c
 SOURCES_FF       = ffmpeg.c
@@ -37,6 +39,8 @@ SOURCES_RPI      = minimal_gpio.c
 SOURCES_FAAD     = faad.c
 SOURCES_SSL      = sslsym.c
 SOURCES_OPUS     = opus.c
+SOURCES_MAD      = mad.c
+SOURCES_MPG123   = mpg.c
 
 LINK_LINUX       = -ldl
 LINK_ALSA        = -lasound
@@ -45,12 +49,14 @@ LINK_PULSEAUDIO  = -lpulse
 LINK_SSL         = -lssl -lcrypto
 LINK_ALAC        = -lalac
 
-LINKALL          = -lmad -lmpg123 -lFLAC -lvorbisfile -lvorbis -logg
+LINKALL          = -lFLAC -lvorbisfile -lvorbis -logg
 LINKALL_FF       = -lavformat -lavcodec -lavutil
 LINKALL_RESAMPLE = -lsoxr
 LINKALL_IR       = -llirc_client
 LINKALL_FAAD     = -lfaad
 LINKALL_OPUS     = -lopusfile -lopus
+LINKALL_MAD      = -lmad
+LINKALL_MPG123   = -lmpg123
 
 DEPS             = squeezelite.h slimproto.h
 
@@ -98,6 +104,12 @@ endif
 ifneq (,$(findstring $(OPT_SSL), $(OPTS)))
 	SOURCES += $(SOURCES_SSL)
 endif
+ifeq (,$(findstring $(OPT_NO_MAD), $(OPTS)))
+	SOURCES += $(SOURCES_MAD)
+endif
+ifeq (,$(findstring $(OPT_NO_MPG123), $(OPTS)))
+	SOURCES += $(SOURCES_MPG123)
+endif
 
 # add optional link options
 ifneq (,$(findstring $(OPT_LINKALL), $(OPTS)))
@@ -119,6 +131,12 @@ ifeq (,$(findstring $(OPT_NO_FAAD), $(OPTS)))
 endif	
 ifneq (,$(findstring $(OPT_SSL), $(OPTS)))
 	LDADD += $(LINK_SSL)
+endif
+ifeq (,$(findstring $(OPT_NO_MAD), $(OPTS)))
+	LDADD += $(LINKALL_MAD)
+endif
+ifeq (,$(findstring $(OPT_NO_MPG123), $(OPTS)))
+	LDADD += $(LINKALL_MPG123)
 endif
 else
 # if not LINKALL and linux add LINK_LINUX

--- a/decode.c
+++ b/decode.c
@@ -183,6 +183,7 @@ void decode_init(log_level level, const char *include_codecs, const char *exclud
 	if (!strstr(exclude_codecs, "pcm")	&& (!include_codecs || (order_codecs = strstr(include_codecs, "pcm"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_pcm());
 
+#if !defined(NO_MAD) && !defined(NO_MPG123)
 	// try mad then mpg for mp3 unless command line option passed
 	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mad")) &&
 		(!include_codecs || (order_codecs = strstr(include_codecs, "mp3")) || (order_codecs = strstr(include_codecs, "mad"))))
@@ -190,6 +191,13 @@ void decode_init(log_level level, const char *include_codecs, const char *exclud
 	else if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mpg")) &&
 		(!include_codecs || (order_codecs = strstr(include_codecs, "mp3")) || (order_codecs = strstr(include_codecs, "mpg"))))
 		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_mpg());
+#elif !defined(NO_MAD)
+	if (!strstr(exclude_codecs, "mp3") && (!include_codecs || (order_codecs = strstr(include_codecs, "mp3"))))
+		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_mad());
+#elif !defined(NO_MPG123)
+	if (!strstr(exclude_codecs, "mp3") && (!include_codecs || (order_codecs = strstr(include_codecs, "mp3"))))
+		sort_codecs((include_codecs ? order_codecs - include_codecs : i), register_mpg123());
+#endif
 
 	LOG_DEBUG("include codecs: %s exclude codecs: %s", include_codecs ? include_codecs : "", exclude_codecs);
 

--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@
 
 #define TITLE "Squeezelite " VERSION ", Copyright 2012-2015 Adrian Smith, 2015-2021 Ralph Irving."
 
-#define CODECS_BASE "flac,pcm,mp3,ogg"
+#define CODECS_BASE "flac,pcm,ogg"
 #if NO_FAAD
 #define CODECS_AAC  ""
 #else
@@ -51,7 +51,13 @@
 #else
 #define CODECS_DSD  ""
 #endif
-#define CODECS_MP3  " (mad,mpg for specific mp3 codec)"
+#if !defined(NO_MAD) && !defined(NO_MPG123)
+#define CODECS_MP3  ",mp3 (mad,mpg for specific mp3 codec)"
+#elif defined(NO_MAD) && defined(NO_MPG123)
+#define CODECS_MP3  ""
+#else
+#define CODECS_MP3  ",mp3"
+#endif
 
 #define CODECS CODECS_BASE CODECS_AAC CODECS_FF CODECS_OPUS CODECS_DSD CODECS_MP3
 


### PR DESCRIPTION
OpenWrt has a patch[1] for squeezelite to disable the build of the mad mp3 decoder. The reason for removing the mad decoder is probably to avoid having to install two mp3 decoders (mad and mpg123) on devices running OpenWrt (typically routers and other small devices with limited storage).

I rewrote the patch to make it configurable and more generic (mad and mpg123 decoders can both be disabled individually).

Do you think this is useful to squeezelite in general and worth merging?

[1] https://github.com/openwrt/packages/blob/master/sound/squeezelite/patches/020-no_libmad.patch