### PR TITLE
Fix manual loading of OpenSSL 1.1

### DIFF
--- a/squeezelite.h
+++ b/squeezelite.h
@@ -172,6 +172,8 @@
 #endif
 
 #if defined (USE_SSL)
+#define OPENSSL_API_COMPAT 0x10000000L
+
 #undef USE_SSL
 #define USE_SSL 1
 #else


### PR DESCRIPTION
sslsym.c doesn't compile with OpenSSL 1.1.1 because functions SSLv23_client_method and SSL_library_init are deprecated and replaced with macros in openssl/ssl.h. And symbol SSL_CTX_set_options also needs to be available to squeezelite.

I'm not super confident that this is the best way to fix the problem, but it seems reasonable to me. Also, I've only tested with OpenSSL versions 1.1.1n and 1.1.1q and on linux.