### PR TITLE
Allow last decode to be made

### DIFF
--- a/vorbis.c
+++ b/vorbis.c
@@ -54,7 +54,7 @@
 
 struct vorbis {
 	OggVorbis_File *vf;
-	bool opened;
+	bool opened, end;
 #if FRAME_BUF	
 	u8_t *write_buf;
 #endif	
@@ -140,7 +140,7 @@ static decode_state vorbis_decode(void) {
 
 	LOCK_S;
 
-	if (stream.state <= DISCONNECT && !_buf_used(streambuf)) {
+	if (stream.state <= DISCONNECT && v->end) {
 		UNLOCK_S;
 		return DECODE_COMPLETE;
 	}
@@ -204,6 +204,7 @@ static decode_state vorbis_decode(void) {
 	);
 	
 	bytes = frames * 2 * channels; // samples returned are 16 bits
+	v->end = frames == 0;
 
 	// write the decoded frames into outputbuf even though they are 16 bits per sample, then unpack them
 #ifdef TREMOR_ONLY	
@@ -311,6 +312,7 @@ static void vorbis_open(u8_t size, u8_t rate, u8_t chan, u8_t endianness) {
 			v->opened = false;
 		}
 	}
+	v->end = false;
 }
 
 static void vorbis_close(void) {


### PR DESCRIPTION
Per https://github.com/ralph-irving/squeezelite/issues/146, the issue is that such codecs have an internal memory buffer and might need a "last call" even when there is no more frames in the streambuf. 

The initial test (exit if stream state is disconnect and outputbuf is empty) fooled me as it is a safeguard in case decoder never ends, not the real ending of decode which is decided later based upon decoder's output. And then I create the problem.

Now, this PR (that I need to verify) adds a state variable that could be avoided as the test can either be done in place but that would add a mutex lock/unlock (slow) or some code can be moved up. I did not want to move code around as there is a reason why I put it below the "new_stream" test, so I'd need to think about that much more. 

I'll leave it to you if you don't like to add un-necessary state variable (which I agree is not a great practice)
