### PR TITLE
Vorbis and Opus fail to play file with large artwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 .vscode/
 *.o
+*.bak
+Backup/
 squeezelite
 squeezelite-pulse
 tools/alsacap
 tools/find_servers
+Debug/
+Release/
+lib/
+MSVC2022/

--- a/stream.c
+++ b/stream.c
@@ -61,8 +61,9 @@ static int _last_error(void) {
 }
 
 static int _recv(int fd, void *buffer, size_t bytes, int options) {
+	int n;
 	if (!ssl) return recv(fd, buffer, bytes, options);
-	int n = SSL_read(ssl, (u8_t*) buffer, bytes);
+	n = SSL_read(ssl, (u8_t*) buffer, bytes);
 	if (n <= 0) {
 		int err = SSL_get_error(ssl, n);
 		if (err == SSL_ERROR_ZERO_RETURN) return 0;
@@ -72,12 +73,13 @@ static int _recv(int fd, void *buffer, size_t bytes, int options) {
 }
 
 static int _send(int fd, void *buffer, size_t bytes, int options) {
-	if (!ssl) return send(fd, buffer, bytes, options);
 	int n = 0;
+	int err;
+	if (!ssl) return send(fd, buffer, bytes, options);
 	do {
 		ERR_clear_error();
 		if ((n = SSL_write(ssl, (u8_t*) buffer, bytes)) >= 0) break;
-		int err = SSL_get_error(ssl, n);
+		err = SSL_get_error(ssl, n);
 		ssl_error = (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE);
 	} while (!ssl_error);
 	return n;

--- a/vorbis.c
+++ b/vorbis.c
@@ -54,7 +54,7 @@
 
 struct vorbis {
 	OggVorbis_File *vf;
-	bool opened;
+	bool opened, end;
 #if FRAME_BUF	
 	u8_t *write_buf;
 #endif	
@@ -140,7 +140,7 @@ static decode_state vorbis_decode(void) {
 
 	LOCK_S;
 
-	if (stream.state <= DISCONNECT && !_buf_used(streambuf)) {
+	if (stream.state <= DISCONNECT && v->end) {
 		UNLOCK_S;
 		return DECODE_COMPLETE;
 	}
@@ -204,6 +204,7 @@ static decode_state vorbis_decode(void) {
 	);
 	
 	bytes = frames * 2 * channels; // samples returned are 16 bits
+	v->end = frames == 0;
 
 	// write the decoded frames into outputbuf even though they are 16 bits per sample, then unpack them
 #ifdef TREMOR_ONLY	
@@ -311,6 +312,7 @@ static void vorbis_open(u8_t size, u8_t rate, u8_t chan, u8_t endianness) {
 			v->opened = false;
 		}
 	}
+	v->end = false;
 }
 
 static void vorbis_close(void) {


### PR DESCRIPTION
Vorbilfile and Opusfile read fully the VorbisComment header. It might contain very large artwork, which causes a problem on my embedded platform as they allocate memory to hold it fully, but that's not an issue here.

Nevertheless, even for regular squeezelite, if the VorbisComment is not fully in the stream buffer, the read callback will return 0 when all data is exhausted and because the streambuffer is locked, file will fail to play with error -133. This PR allow more data to be added to the streambuf while waiting in the read_cb

I also removed some code which I'm pretty sure is useless. This is something I've left when I changed the detection of end of track last year to handle the "last few frames of track would not play". In fact the DECODE_COMPLETE shall simply be sent from the main loop, there is no need to test anything at the beginning, especially testing the fulness of the output buffer is not a good criteria anyway.
