### PR TITLE
differentiate flush from quit

### DIFF
--- a/output.c
+++ b/output.c
@@ -452,12 +452,14 @@ void output_flush(void) {
 	UNLOCK;
 }
 
-void output_flush_streaming(void) {
+bool output_flush_streaming(void) {
 	LOG_INFO("flush output buffer (streaming)");
 	LOCK;
+	bool flushed = output.track_start != NULL;
 	if (output.track_start) {
 		outputbuf->writep = output.track_start;
 		output.track_start = NULL;
 	}
 	UNLOCK;
+	return flushed;
 }

--- a/output.c
+++ b/output.c
@@ -436,7 +436,7 @@ void output_close_common(void) {
 }
 
 void output_flush(void) {
-	LOG_INFO("flush output buffer");
+	LOG_INFO("flush output buffer (full)");
 	buf_flush(outputbuf);
 	LOCK;
 	output.fade = FADE_INACTIVE;
@@ -449,5 +449,15 @@ void output_flush(void) {
 		output.delay_active = false;
 	}
 	output.frames_played = 0;
+	UNLOCK;
+}
+
+void output_flush_streaming(void) {
+	LOG_INFO("flush output buffer (streaming)");
+	LOCK;
+	if (output.track_start) {
+		outputbuf->writep = output.track_start;
+		output.track_start = NULL;
+	}
 	UNLOCK;
 }

--- a/slimproto.c
+++ b/slimproto.c
@@ -291,14 +291,17 @@ static void process_strm(u8_t *pkt, int len) {
 		sendSTAT("STMf", 0);
 		buf_flush(streambuf);
 		break;
-	case 'f':
-		decode_flush();
-		output_flush_streaming();
-		if (stream_disconnect()) {
-			sendSTAT("STMf", 0);
+	case 'f': 
+		{
+			decode_flush();
+			// we can have fully finished the current streaming, that's still a flush
+			bool flushed = output_flush_streaming();
+			if (flushed || stream_disconnect()) {
+				sendSTAT("STMf", 0);
+			}
+			buf_flush(streambuf);
+			break;
 		}
-		buf_flush(streambuf);
-		break;
 	case 'p':
 		{
 			unsigned interval = unpackN(&strm->replay_gain);

--- a/slimproto.c
+++ b/slimproto.c
@@ -296,7 +296,7 @@ static void process_strm(u8_t *pkt, int len) {
 			decode_flush();
 			// we can have fully finished the current streaming, that's still a flush
 			bool flushed = output_flush_streaming();
-			if (flushed || stream_disconnect()) {
+			if (stream_disconnect() || flushed) {
 				sendSTAT("STMf", 0);
 			}
 			buf_flush(streambuf);

--- a/slimproto.c
+++ b/slimproto.c
@@ -293,8 +293,7 @@ static void process_strm(u8_t *pkt, int len) {
 		break;
 	case 'f':
 		decode_flush();
-		output_flush();
-		status.frames_played = 0;
+		output_flush_streaming();
 		if (stream_disconnect()) {
 			sendSTAT("STMf", 0);
 		}

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -688,7 +688,7 @@ struct outputstate {
 void output_init_common(log_level level, const char *device, unsigned output_buf_size, unsigned rates[], unsigned idle);
 void output_close_common(void);
 void output_flush(void);
-void output_flush_streaming(void);
+bool output_flush_streaming(void);
 // _* called with mutex locked
 frames_t _output_frames(frames_t avail);
 void _checkfade(bool);

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -688,6 +688,7 @@ struct outputstate {
 void output_init_common(log_level level, const char *device, unsigned output_buf_size, unsigned rates[], unsigned idle);
 void output_close_common(void);
 void output_flush(void);
+void output_flush_streaming(void);
 // _* called with mutex locked
 frames_t _output_frames(frames_t avail);
 void _checkfade(bool);


### PR DESCRIPTION
Per https://github.com/ralph-irving/squeezelite/issues/193, this goes together with https://github.com/Logitech/slimserver/pull/964 in trying to address the case where players with large buffers don't allow playlist to be modified at the current track when the next track has already been streamed. It exists with all devices but for the PR on LMS to work, the client has to flush only the streaming track when receiving a strmf. 

This PR has been working for far in the tests I've made, but very likely more needs to be verified, so this is rather WIP