### PR TITLE
Ogg metadata (and a bit more)

### DIFF
--- a/flac.c
+++ b/flac.c
@@ -72,6 +72,7 @@ struct flac {
 	FLAC__bool (* FLAC__stream_decoder_process_single)(FLAC__StreamDecoder *decoder);
 	FLAC__StreamDecoderState (* FLAC__stream_decoder_get_state)(const FLAC__StreamDecoder *decoder);
 	void (*FLAC__stream_decoder_set_metadata_respond)(FLAC__StreamDecoder* decoder, FLAC__MetadataType type);
+	FLAC__bool (*FLAC__stream_decoder_set_ogg_chaining)(FLAC__StreamDecoder* decoder, FLAC__bool allow);
 #endif
 };
 
@@ -276,6 +277,7 @@ static void flac_open(u8_t sample_size, u8_t sample_rate, u8_t channels, u8_t en
 	
 	if ( f->container == 'o' ) {
 		LOG_INFO("ogg/flac container - using init_ogg_stream");
+		FLAC(f, stream_decoder_set_ogg_chaining, f->decoder, true);
 		FLAC(f, stream_decoder_set_metadata_respond, f->decoder, FLAC__METADATA_TYPE_VORBIS_COMMENT);
 		FLAC(f, stream_decoder_init_ogg_stream, f->decoder, &read_cb, NULL, NULL, NULL, NULL, &write_cb, &metadata_cb, &error_cb, NULL);
 	} else {
@@ -325,6 +327,7 @@ static bool load_flac() {
 	f->FLAC__stream_decoder_process_single = dlsym(handle, "FLAC__stream_decoder_process_single");
 	f->FLAC__stream_decoder_get_state = dlsym(handle, "FLAC__stream_decoder_get_state");
 	f->FLAC__stream_decoder_set_metadata_respond = dlsym(handle, "FLAC__stream_decoder_set_metadata_respond");
+	f->FLAC__stream_decoder_set_ogg_chaining = dlsym(handle, "FLAC__stream_decoder_set_ogg_chaining");
 
 	if ((err = dlerror()) != NULL) {
 		LOG_INFO("dlerror: %s", err);		

--- a/flac.c
+++ b/flac.c
@@ -71,6 +71,7 @@ struct flac {
 	);
 	FLAC__bool (* FLAC__stream_decoder_process_single)(FLAC__StreamDecoder *decoder);
 	FLAC__StreamDecoderState (* FLAC__stream_decoder_get_state)(const FLAC__StreamDecoder *decoder);
+	void (*FLAC__stream_decoder_set_metadata_respond)(FLAC__StreamDecoder* decoder, FLAC__MetadataType type);
 #endif
 };
 
@@ -108,6 +109,23 @@ extern struct processstate process;
 #define FLAC(h, fn, ...) (h)->FLAC__##fn(__VA_ARGS__)
 #define FLAC_A(h, a)     (h)->FLAC__ ## a
 #endif
+
+static void metadata_cb(const FLAC__StreamDecoder* decoder, const FLAC__StreamMetadata* metadata, void* client_data) {
+	switch (metadata->type) {
+	case FLAC__METADATA_TYPE_STREAMINFO:
+		LOG_INFO("stream parameters rate:%d, channels:%d, size:%d", metadata->data.stream_info.sample_rate, 
+				 metadata->data.stream_info.channels, metadata->data.stream_info.bits_per_sample);
+		break;
+	case FLAC__METADATA_TYPE_VORBIS_COMMENT: {
+		FLAC__StreamMetadata_VorbisComment_Entry* comment = metadata->data.vorbis_comment.comments;
+		for (int i = 0; i < metadata->data.vorbis_comment.num_comments; i++, comment++) {
+			LOG_INFO("stream metadata %*s", comment->length, comment->entry);
+		}
+	}
+	default:
+		break;
+	}
+}
 
 static FLAC__StreamDecoderReadStatus read_cb(const FLAC__StreamDecoder *decoder, FLAC__byte buffer[], size_t *want, void *client_data) {
 	size_t bytes;
@@ -258,7 +276,8 @@ static void flac_open(u8_t sample_size, u8_t sample_rate, u8_t channels, u8_t en
 	
 	if ( f->container == 'o' ) {
 		LOG_INFO("ogg/flac container - using init_ogg_stream");
-		FLAC(f, stream_decoder_init_ogg_stream, f->decoder, &read_cb, NULL, NULL, NULL, NULL, &write_cb, NULL, &error_cb, NULL);
+		FLAC(f, stream_decoder_set_metadata_respond, f->decoder, FLAC__METADATA_TYPE_VORBIS_COMMENT);
+		FLAC(f, stream_decoder_init_ogg_stream, f->decoder, &read_cb, NULL, NULL, NULL, NULL, &write_cb, &metadata_cb, &error_cb, NULL);
 	} else {
 		FLAC(f, stream_decoder_init_stream, f->decoder, &read_cb, NULL, NULL, NULL, NULL, &write_cb, NULL, &error_cb, NULL);
 	}
@@ -305,6 +324,7 @@ static bool load_flac() {
 	f->FLAC__stream_decoder_init_ogg_stream = dlsym(handle, "FLAC__stream_decoder_init_ogg_stream");
 	f->FLAC__stream_decoder_process_single = dlsym(handle, "FLAC__stream_decoder_process_single");
 	f->FLAC__stream_decoder_get_state = dlsym(handle, "FLAC__stream_decoder_get_state");
+	f->FLAC__stream_decoder_set_metadata_respond = dlsym(handle, "FLAC__stream_decoder_set_metadata_respond");
 
 	if ((err = dlerror()) != NULL) {
 		LOG_INFO("dlerror: %s", err);		

--- a/output.c
+++ b/output.c
@@ -60,7 +60,7 @@ frames_t _output_frames(frames_t avail) {
 	silence = false;
 
 	// start when threshold met
-	if (output.state == OUTPUT_BUFFER && (frames * BYTES_PER_FRAME) > output.threshold * output.next_sample_rate / 10 && frames > output.start_frames) {
+	if (output.state == OUTPUT_BUFFER && frames > output.threshold * output.next_sample_rate / 10 && frames > output.start_frames) {
 		output.state = OUTPUT_RUNNING;
 		LOG_INFO("start buffer frames: %u", frames);
 		wake_controller();

--- a/slimproto.c
+++ b/slimproto.c
@@ -373,7 +373,7 @@ static void process_strm(u8_t *pkt, int len) {
 				stream_file(header, header_len, strm->threshold * 1024);
 				autostart -= 2;
 			} else {
-				stream_sock(ip, port, strm->flags & 0x20, header, header_len, strm->threshold * 1024, autostart >= 2);
+				stream_sock(ip, port, strm->flags & 0x20, strm->format, header, header_len, strm->threshold * 1024, autostart >= 2);
 			}
 			sendSTAT("STMc", 0);
 			sentSTMu = sentSTMo = sentSTMl = false;

--- a/slimproto.c
+++ b/slimproto.c
@@ -373,7 +373,9 @@ static void process_strm(u8_t *pkt, int len) {
 				stream_file(header, header_len, strm->threshold * 1024);
 				autostart -= 2;
 			} else {
-				stream_sock(ip, port, strm->flags & 0x20, strm->format, header, header_len, strm->threshold * 1024, autostart >= 2);
+				stream_sock(ip, port, strm->flags & 0x20, 
+						    strm->format == 'o' || strm->format == 'u' || (strm->format == 'f' && strm->pcm_sample_size == 'o'),
+							header, header_len, strm->threshold * 1024, autostart >= 2);
 			}
 			sendSTAT("STMc", 0);
 			sentSTMu = sentSTMo = sentSTMl = false;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -490,6 +490,7 @@ void *dlopen(const char *filename, int flag);
 void *dlsym(void *handle, const char *symbol);
 char *dlerror(void);
 int poll(struct pollfd *fds, unsigned long numfds, int timeout);
+#define strncasecmp strnicmp
 #endif
 #if LINUX || FREEBSD
 void touch_memory(u8_t *buf, size_t size);
@@ -543,12 +544,26 @@ struct streamstate {
 	u32_t meta_next;
 	u32_t meta_left;
 	bool  meta_send;
+	struct {
+		enum { STREAM_OGG_OFF, STREAM_OGG_SYNC, STREAM_OGG_HEADER, STREAM_OGG_SEGMENTS, STREAM_OGG_PAGE } state;
+		u32_t want, miss, match;
+		u8_t* data;
+#pragma pack(push, 1)
+		struct {
+			char pattern[4];
+			u8_t version, type;
+			u64_t granule;
+			u32_t serial, page, checksum;
+			u8_t count;
+		} header;
+#pragma pack(pop)
+	} ogg;
 };
 
 void stream_init(log_level level, unsigned stream_buf_size);
 void stream_close(void);
 void stream_file(const char *header, size_t header_len, unsigned threshold);
-void stream_sock(u32_t ip, u16_t port, bool use_ssl, const char *header, size_t header_len, unsigned threshold, bool cont_wait);
+void stream_sock(u32_t ip, u16_t port, bool use_ssl, char codec, const char *header, size_t header_len, unsigned threshold, bool cont_wait);
 bool stream_disconnect(void);
 
 // decode.c

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -171,6 +171,13 @@
 #define LINKALL   0
 #endif
 
+#if defined(USE_LIBOGG)
+#undef USE_LIBOGG
+#define USE_LIBOGG 1
+#else
+#define USE_LIBOGG 0
+#endif
+
 #if defined (USE_SSL)
 #define OPENSSL_API_COMPAT 0x10000000L
 
@@ -196,6 +203,7 @@
 #define LIBMAD  "libmad.so.0"
 #define LIBMPG "libmpg123.so.0"
 #define LIBVORBIS "libvorbisfile.so.3"
+#define LIBOGG "libogg.so.0"
 #define LIBOPUS "libopusfile.so.0"
 #define LIBTREMOR "libvorbisidec.so.1"
 #define LIBFAAD "libfaad.so.2"
@@ -210,6 +218,7 @@
 #define LIBFLAC "libFLAC.%d.dylib"
 #define LIBMAD  "libmad.0.dylib"
 #define LIBMPG "libmpg123.0.dylib"
+#define LIBOGG "libogg.0.dylib"
 #define LIBVORBIS "libvorbisfile.3.dylib"
 #define LIBTREMOR "libvorbisidec.1.dylib"
 #define LIBOPUS "libopusfile.0.dylib"
@@ -224,6 +233,7 @@
 #define LIBFLAC "libFLAC.dll"
 #define LIBMAD  "libmad-0.dll"
 #define LIBMPG "libmpg123-0.dll"
+#define LIBOGG "libogg.dll"
 #define LIBVORBIS "libvorbisfile.dll"
 #define LIBOPUS "libopusfile-0.dll"
 #define LIBTREMOR "libvorbisidec.dll"
@@ -238,6 +248,7 @@
 #define LIBFLAC "libFLAC.so.%d"
 #define LIBMAD  "libmad.so.0"
 #define LIBMPG "libmpg123.so.0"
+#define LIBOGG "libogg.so.0"
 #define LIBVORBIS "libvorbisfile.so.3"
 #define LIBTREMOR "libvorbisidec.so.1"
 #define LIBOPUS "libopusfile.so.1"
@@ -544,20 +555,6 @@ struct streamstate {
 	u32_t meta_next;
 	u32_t meta_left;
 	bool  meta_send;
-	struct {
-		enum { STREAM_OGG_OFF, STREAM_OGG_SYNC, STREAM_OGG_HEADER, STREAM_OGG_SEGMENTS, STREAM_OGG_PAGE } state;
-		u32_t want, miss, match;
-		u8_t* data, segments[255];
-#pragma pack(push, 1)
-		struct {
-			char pattern[4];
-			u8_t version, type;
-			u64_t granule;
-			u32_t serial, page, checksum;
-			u8_t count;
-		} header;
-#pragma pack(pop)
-	} ogg;
 };
 
 void stream_init(log_level level, unsigned stream_buf_size);

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -547,7 +547,7 @@ struct streamstate {
 	struct {
 		enum { STREAM_OGG_OFF, STREAM_OGG_SYNC, STREAM_OGG_HEADER, STREAM_OGG_SEGMENTS, STREAM_OGG_PAGE } state;
 		u32_t want, miss, match;
-		u8_t* data;
+		u8_t* data, segments[255];
 #pragma pack(push, 1)
 		struct {
 			char pattern[4];

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -560,7 +560,7 @@ struct streamstate {
 void stream_init(log_level level, unsigned stream_buf_size);
 void stream_close(void);
 void stream_file(const char *header, size_t header_len, unsigned threshold);
-void stream_sock(u32_t ip, u16_t port, bool use_ssl, char codec, const char *header, size_t header_len, unsigned threshold, bool cont_wait);
+void stream_sock(u32_t ip, u16_t port, bool use_ssl, bool use_ogg, const char *header, size_t header_len, unsigned threshold, bool cont_wait);
 bool stream_disconnect(void);
 
 // decode.c

--- a/stream.c
+++ b/stream.c
@@ -399,6 +399,7 @@ static void stream_ogg(size_t n) {
 					}
 				}
 
+				ogg.flac = false;
 				stream.meta_send = true;
 				wake_controller();
 				LOG_INFO("Ogg metadata length: %u", stream.header_len - 3);

--- a/stream.c
+++ b/stream.c
@@ -327,7 +327,7 @@ static void stream_ogg(size_t n) {
 
 				stream.meta_send = true;
 				wake_controller();
-				LOG_INFO("Ogg meta len: %u", stream.header_len);
+				LOG_INFO("Ogg metadata length: %u", stream.header_len - 3);
 				break;
 			}
 			free(stream.ogg.data);

--- a/stream.c
+++ b/stream.c
@@ -349,6 +349,7 @@ static void stream_ogg(size_t n) {
 			// calculate size of page using lacing values
 			for (size_t i = 0; i < ogg.want; i++) ogg.miss += ogg.data[i];
 			ogg.want = ogg.miss;
+
 			if (ogg.header.granule == 0 || (ogg.header.granule == -1 && ogg.granule == 0)) {
 				// granule 0 means a new stream, so let's look into it
 				ogg.state = STREAM_OGG_PAGE;
@@ -440,7 +441,7 @@ static void stream_ogg(size_t n) {
 			size_t ofs = 0;
 
 			// if case of OggFlac, VorbisComment is a flac METADATA_BLOC as 2nd packet (4 bytes in)
-			if (ogg.flac) offset = 4;
+			if (ogg.flac) ofs = 4;
 			else if (!memcmp(ogg.packet.packet, "\x7f""FLAC", 5)) ogg.flac = true;
 			else for (char** tag = (char* []){ "\x3vorbis", "OpusTags", NULL }; *tag && !ofs; tag++) if (!memcmp(ogg.packet.packet, *tag, strlen(*tag))) ofs = strlen(*tag);
 

--- a/stream.c
+++ b/stream.c
@@ -742,7 +742,7 @@ void stream_sock(u32_t ip, u16_t port, bool use_ssl, char codec, const char *hea
 	stream.threshold = threshold;
 
 	stream.ogg.miss = stream.ogg.match = 0;
-	stream.ogg.state = (codec == 'o' || codec == 'p') ? STREAM_OGG_SYNC : STREAM_OGG_OFF;
+	stream.ogg.state = STREAM_OGG_SYNC;
 
 	UNLOCK;
 }
@@ -765,7 +765,7 @@ bool stream_disconnect(void) {
 	stream.state = STOPPED;
 	if (stream.ogg.state == STREAM_OGG_HEADER && stream.ogg.data) free(stream.ogg.data);
 	stream.ogg.data = NULL;
-	
+
 	UNLOCK;
 	return disc;
 }


### PR DESCRIPTION
This PR adds to squeezelite what is on all SqueezeBox2 and SqueezePlay: ogg streams of type vorbis, opus and flac is scanned for metadata (in direct or proxied mode) and forwarded back to LMS to he handled in Slim::Player::Protocols::HTTP::parseMetadata. 

This is done for every ogg (webradio/local/streaming) but is useful mainly for webradio as others are scanned if possible by LMS itself. For flac, it could be argued that metadata parsing could be done inside the decoder, not the streamer as OggFlac offers metadata callbacks, but vorbis does not, so it's better to do all in streams, where metadata handling should be done anyway.

There is a bit more in that PR as you can see the output threshold fix in there as well. You can decide to just take and I'll rebase my PR.

Note that OggFlac **playback** with multiple streams only works if you use updated library here https://github.com/philippe44/flac and the PR to flac is here https://github.com/xiph/flac/pull/667. I don't know if the maintainer will be willing to accept it (in which case more work needs to be done, but for now and our squeezelite needs, these changes are enough)