### PR TITLE
fix output buffer threshold for huge sample rates

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -263,6 +263,12 @@ unsigned decode_newstream(unsigned sample_rate, unsigned supported_rates[]) {
 		}
 	);
 
+	// reduce threshold if we don't have enough room in outputbuf
+	if (output.threshold * sample_rate / 10 > outputbuf->size / BYTES_PER_FRAME / 2) {
+		output.threshold = (outputbuf->size / BYTES_PER_FRAME / 2 * 10) / sample_rate;
+		LOG_WARN("output buffer too small - reducing threshold to %d ms", output.threshold * 10);
+	}
+
 	return sample_rate;
 }
 


### PR DESCRIPTION
I think putting the test in decode_newstream is the right place as we have the updated sample rate, the output is locked and it's universal for all codecs.