### PR TITLE
Alternate option for OggFlac chaining compatibility

### DIFF
--- a/flac.c
+++ b/flac.c
@@ -346,12 +346,12 @@ static bool load_flac() {
 	// ignore error for this new API
 	f->FLAC__stream_decoder_set_ogg_chaining = dlsym(handle, "FLAC__stream_decoder_set_ogg_chaining");
 	if (!f->FLAC__stream_decoder_set_ogg_chaining) {
-		LOG_WARN("OggFlac chaining disabled");
+		LOG_INFO("OggFlac chaining disabled");
 	}
 	
 	LOG_INFO("loaded %s", name);
 #elif !defined(FLAC__OGG_CHAINING)
-	LOG_WARN("OggFlac chaining disabled");
+	LOG_INFO("OggFlac chaining disabled");
 #endif
 
 	return true;

--- a/flac.c
+++ b/flac.c
@@ -350,7 +350,7 @@ static bool load_flac() {
 	}
 	
 	LOG_INFO("loaded %s", name);
-#elif !defined FLAG__OGG_CHAINING
+#elif !defined(FLAC__OGG_CHAINING)
 	LOG_WARN("OggFlac chaining disabled");
 #endif
 

--- a/flac.c
+++ b/flac.c
@@ -23,12 +23,6 @@
 
 #include <FLAC/stream_decoder.h>
 
-#if USE_LIBOGG
-#if !WIN && LINKALL
-FLAC_API FLAC__bool __attribute__((weak)) FLAC__stream_decoder_set_ogg_chaining(FLAC__StreamDecoder* decoder, FLAC__bool value) { };
-#endif
-#endif
-
 #if BYTES_PER_FRAME == 4		
 #define ALIGN8(n) 	(n << 8)		
 #define ALIGN16(n) 	(n)
@@ -78,9 +72,7 @@ struct flac {
 	FLAC__bool (* FLAC__stream_decoder_process_single)(FLAC__StreamDecoder *decoder);
 	FLAC__StreamDecoderState (* FLAC__stream_decoder_get_state)(const FLAC__StreamDecoder *decoder);
 	void (*FLAC__stream_decoder_set_metadata_respond)(FLAC__StreamDecoder* decoder, FLAC__MetadataType type);
-#if USE_LIBOGG
 	FLAC__bool (*FLAC__stream_decoder_set_ogg_chaining)(FLAC__StreamDecoder* decoder, FLAC__bool allow);
-#endif
 #endif
 };
 
@@ -285,12 +277,16 @@ static void flac_open(u8_t sample_size, u8_t sample_rate, u8_t channels, u8_t en
 	
 	if ( f->container == 'o' ) {
 		LOG_INFO("ogg/flac container - using init_ogg_stream");
-#if USE_LIBOGG
-#if !LINKALL
-		if (f->FLAC__stream_decoder_set_ogg_chaining) f->FLAC__stream_decoder_set_ogg_chaining(f->decoder, true);
-#else
+#if LINKALL
+#ifdef FLAC__OGG_CHAINING
 		FLAC__stream_decoder_set_ogg_chaining(f->decoder, true);
+#else 
+#pragma message ("OggFlac library does not support chaining") 
 #endif
+#else
+		if (f->FLAC__stream_decoder_set_ogg_chaining) {
+			f->FLAC__stream_decoder_set_ogg_chaining(f->decoder, true);
+		}
 #endif
 		FLAC(f, stream_decoder_set_metadata_respond, f->decoder, FLAC__METADATA_TYPE_VORBIS_COMMENT);
 		FLAC(f, stream_decoder_init_ogg_stream, f->decoder, &read_cb, NULL, NULL, NULL, NULL, &write_cb, &metadata_cb, &error_cb, NULL);
@@ -347,11 +343,15 @@ static bool load_flac() {
 		return false;
 	}
 
-#if USE_LIBOGG
 	// ignore error for this new API
 	f->FLAC__stream_decoder_set_ogg_chaining = dlsym(handle, "FLAC__stream_decoder_set_ogg_chaining");
-#endif
+	if (!f->FLAC__stream_decoder_set_ogg_chaining) {
+		LOG_WARN("OggFlac chaining disabled");
+	}
+	
 	LOG_INFO("loaded %s", name);
+#elif !defined FLAG__OGG_CHAINING
+	LOG_WARN("OggFlac chaining disabled");
 #endif
 
 	return true;


### PR DESCRIPTION
I decided to change logic for my own version (bridges) so here is a version that is compatible with all existing libraries, static and dynamic, compile and runtime. With my updated version of libflac, it will work on static link. On dynamic link, it will try to load the chaining system and just create a log if failing. On static link, it will spit a compile-time message and one runtime log if chaining is missing.

Per your comment, feel free to ignore that, I just offered it to avoid forcing disabling USE_LIBOGG in all cases.