### PR TITLE
MacOS build enhancements, support for LIRC IR on MacOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.o
 squeezelite
 squeezelite-pulse
+squeezelite-osx
 tools/alsacap
 tools/find_servers

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -3,7 +3,7 @@
 # For Intel-only: ARCHS="x86_64 i386"
 # For Universal: ARCHS="x86_64 arm64"
 # For single arch: ARCHS="arm64" or ARCHS="x86_64"
-ARCHS ?= arm64
+ARCHS ?= $(shell uname -m)
 ARCH_FLAGS = $(foreach arch,$(ARCHS),-arch $(arch))
 
 # Determine Homebrew path dynamically

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,7 +1,59 @@
 # OSX build - adjust -I to point to header files for codecs and portaudio
-CFLAGS  = -arch x86_64 -arch i386 -Wall -fPIC -O2 -I./include $(OPTS)
-LDFLAGS = -arch x86_64 -arch i386 -lpthread libportaudio.a -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework Carbon
+# Use ARCHS variable to control architectures for multi-arch (fat) binary
+# For Intel-only: ARCHS="x86_64 i386"
+# For Universal: ARCHS="x86_64 arm64"
+# For single arch: ARCHS="arm64" or ARCHS="x86_64"
+ARCHS ?= arm64
+ARCH_FLAGS = $(foreach arch,$(ARCHS),-arch $(arch))
+
+# Determine Homebrew path dynamically
+BREW_PATH ?= $(shell brew --prefix 2>/dev/null)
+INCLUDE_PATHS = -I./include
+LIB_PATHS =
+
+ifdef BREW_PATH
+  INCLUDE_PATHS += -I$(BREW_PATH)/include
+  LIB_PATHS += -L$(BREW_PATH)/lib
+endif
+
+# Add /usr/local as fallback if it exists
+ifneq ($(wildcard /usr/local/include),)
+  INCLUDE_PATHS += -I/usr/local/include
+  LIB_PATHS += -L/usr/local/lib
+endif
+
+# Use pkg-config for all libraries (except portaudio which is handled by macOS frameworks)
+LIRC_CFLAGS := $(shell pkg-config --cflags lirc)
+LIRC_LIBS := $(shell pkg-config --libs lirc)
+
+FLAC_CFLAGS := $(shell pkg-config --cflags flac)
+FLAC_LIBS := $(shell pkg-config --libs flac)
+
+OGG_VORBIS_CFLAGS := $(shell pkg-config --cflags vorbis vorbisfile ogg)
+OGG_VORBIS_LIBS := $(shell pkg-config --libs vorbis vorbisfile ogg)
+
+SOXR_CFLAGS := $(shell pkg-config --cflags soxr)
+SOXR_LIBS := $(shell pkg-config --libs soxr)
+
+FFMPEG_CFLAGS := $(shell pkg-config --cflags libavformat libavcodec libavutil)
+FFMPEG_LIBS := $(shell pkg-config --libs libavformat libavcodec libavutil)
+
+SSL_CFLAGS := $(shell pkg-config --cflags openssl)
+SSL_LIBS := $(shell pkg-config --libs openssl)
+
+# For portaudio we use the framework approach which is handled in the LDADD variable
+PORTAUDIO_CFLAGS := $(shell pkg-config --cflags portaudio-2.0)
+
+PKG_CFLAGS := $(LIRC_CFLAGS) $(FLAC_CFLAGS) $(OGG_VORBIS_CFLAGS) $(SOXR_CFLAGS) $(FFMPEG_CFLAGS) $(SSL_CFLAGS) $(PORTAUDIO_CFLAGS)
+PKG_LIBS := $(LIRC_LIBS) $(FLAC_LIBS) $(OGG_VORBIS_LIBS) $(SOXR_LIBS) $(FFMPEG_LIBS) $(SSL_LIBS)
+
+OPTS ?= -DOSSX -DPORTAUDIO -DSELFPIPE -DRESAMPLE -DFF -DVISEXPORT -DDSD -DIR -DUSE_SSL
+CFLAGS  = $(ARCH_FLAGS) -Wall -fPIC -O2 $(INCLUDE_PATHS) $(PKG_CFLAGS) $(OPTS)
+CXXFLAGS = $(ARCH_FLAGS) -Wall -fPIC -O2 $(INCLUDE_PATHS) $(PKG_CFLAGS) $(OPTS)
+LDFLAGS = $(ARCH_FLAGS) $(LIB_PATHS)
+LDADD   = -lpthread -lm -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework Carbon $(PKG_LIBS)
 
 EXECUTABLE ?= squeezelite-osx
+
 
 include Makefile

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -23,8 +23,19 @@ ifneq ($(wildcard /usr/local/include),)
 endif
 
 # Use pkg-config for all libraries (except portaudio which is handled by macOS frameworks)
-LIRC_CFLAGS := $(shell pkg-config --cflags lirc)
-LIRC_LIBS := $(shell pkg-config --libs lirc)
+# Check if lirc is available
+LIRC_AVAILABLE := $(shell pkg-config --exists lirc && echo yes || echo no)
+ifeq ($(LIRC_AVAILABLE),yes)
+  LIRC_CFLAGS := $(shell pkg-config --cflags lirc)
+  LIRC_LIBS := $(shell pkg-config --libs lirc)
+  ENABLE_IR := -DIR
+  $(info IR support enabled - lirc found)
+else
+  LIRC_CFLAGS :=
+  LIRC_LIBS :=
+  ENABLE_IR :=
+  $(info IR support disabled - lirc not found)
+endif
 
 FLAC_CFLAGS := $(shell pkg-config --cflags flac)
 FLAC_LIBS := $(shell pkg-config --libs flac)
@@ -47,7 +58,7 @@ PORTAUDIO_CFLAGS := $(shell pkg-config --cflags portaudio-2.0)
 PKG_CFLAGS := $(LIRC_CFLAGS) $(FLAC_CFLAGS) $(OGG_VORBIS_CFLAGS) $(SOXR_CFLAGS) $(FFMPEG_CFLAGS) $(SSL_CFLAGS) $(PORTAUDIO_CFLAGS)
 PKG_LIBS := $(LIRC_LIBS) $(FLAC_LIBS) $(OGG_VORBIS_LIBS) $(SOXR_LIBS) $(FFMPEG_LIBS) $(SSL_LIBS)
 
-OPTS ?= -DOSSX -DPORTAUDIO -DSELFPIPE -DRESAMPLE -DFF -DVISEXPORT -DDSD -DIR -DUSE_SSL
+OPTS ?= -DOSSX -DPORTAUDIO -DSELFPIPE -DRESAMPLE -DFF -DVISEXPORT -DDSD $(ENABLE_IR) -DUSE_SSL
 CFLAGS  = $(ARCH_FLAGS) -Wall -fPIC -O2 $(INCLUDE_PATHS) $(PKG_CFLAGS) $(OPTS)
 CXXFLAGS = $(ARCH_FLAGS) -Wall -fPIC -O2 $(INCLUDE_PATHS) $(PKG_CFLAGS) $(OPTS)
 LDFLAGS = $(ARCH_FLAGS) $(LIB_PATHS)

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -147,7 +147,7 @@
 #define VISEXPORT 0
 #endif
 
-#if LINUX && defined(IR)
+#if (LINUX || OSX) && defined(IR)
 #undef IR
 #define IR 1
 #else
@@ -227,6 +227,7 @@
 #define LIBAVCODEC  "libavcodec.%d.dylib"
 #define LIBAVFORMAT "libavformat.%d.dylib"
 #define LIBSOXR "libsoxr.0.dylib"
+#define LIBLIRC "liblirc_client.0.dylib"
 #endif
 
 #if WIN


### PR DESCRIPTION
Just some things I ended up doing to my local copy, I thought I'd see if you were interested in incorporating them.

This all started when I learned that the release builds for MacOS don't enable many of the build flags by default.
My local copy is now happy looking like this:

```
Squeezelite 2.0.0-1524, Copyright 2012-2015 Adrian Smith, 2015-2025 Ralph Irving. See -t for license terms
Usage: ./squeezelite-osx [options]
  -s <server>[:<port>]	Connect to specified server, otherwise uses autodiscovery to find server
  -o <output device>	Specify output device, default "default", - = output to stdout
  -l 			List output devices
  -a <l>:<r>		Specify Portaudio params to open output device, l = target latency in ms, r = allow OSX to resample (0|1)
  -a <f>		Specify sample format (16|24|32) of output file when using -o - to output samples to stdout (interleaved little endian only)
  -b <stream>:<output>	Specify internal Stream and Output buffer sizes in Kbytes. Default is 2048:3445
  -c <codec1>,<codec2>	Restrict codecs to those specified, otherwise load all available codecs; known codecs: flac,pcm,ogg,aac,dsd,mp3 (mad,mpg for specific mp3 codec)
  			Codecs reported to LMS in order listed, allowing codec priority refinement.
  -C <timeout>		Close output device when idle after timeout seconds, default is to keep it open while player is 'on'
  -d <log>=<level>	Set logging level, logs: all|slimproto|stream|decode|output|ir, level: info|debug|sdebug
  -e <codec1>,<codec2>	Explicitly exclude native support of one or more codecs; known codecs: flac,pcm,ogg,aac,dsd,mp3 (mad,mpg for specific mp3 codec)
  -f <logfile>		Write debug to logfile
  -i [<filename>]	Enable lirc remote control support (lirc config file ~/.lircrc used if filename not specified)
  -m <mac addr>		Set mac address, format: ab:cd:ef:12:34:56
  -M <modelname>	Set the squeezelite player model name sent to the server (default: SqueezeLite)
  -n <name>		Set the player name
  -N <filename>		Store player name in filename to allow server defined name changes to be shared between servers (not supported with -n)
  -W			Read wave and aiff format from header, ignore server parameters
  -r <rates>[:<delay>]	Sample rates supported, allows output to be off when squeezelite is started; rates = <maxrate>|<minrate>-<maxrate>|<rate1>,<rate2>,<rate3>; delay = optional delay switching rates in ms
  -R -u [params]	Resample, params = <recipe>:<flags>:<attenuation>:<precision>:<passband_end>:<stopband_start>:<phase_response>,
  			 recipe = (v|h|m|l|q)(L|I|M)(s) [E|X], E = exception - resample only if native rate not supported, X = async - resample to max rate for device, otherwise to max sync rate
  			 flags = num in hex,
  			 attenuation = attenuation in dB to apply (default is -1db if not explicitly set),
  			 precision = number of bits precision (NB. HQ = 20. VHQ = 28),
  			 passband_end = number in percent (0dB pt. bandwidth to preserve. nyquist = 100%),
  			 stopband_start = number in percent (Aliasing/imaging control. > passband_end),
  			 phase_response = 0-100 (0 = minimum / 50 = linear / 100 = maximum)
  -D [delay]		Output device supports DSD over PCM (DoP), delay = optional delay switching between PCM and DoP in ms
  -v 			Visualizer support
  -Z <rate>		Report rate to server in helo as the maximum sample rate we can support
  -t 			License terms
  -? 			Display this help text

Build options: OSX PORTAUDIO SELFPIPE RESAMPLE VISEXPORT IR DSD SSL
```

At the moment a working LIRC on MacOS requires some patches I've done, I'm separately working on contributing those back to LIRC upstream. Because of that, this checks to see if LIRC is installed before enabling that build option.