### PR TITLE
Fix dynamic loading of libFLAC.so

### DIFF
--- a/flac.c
+++ b/flac.c
@@ -328,7 +328,7 @@ static bool load_flac() {
 	char name[30];
 	char *err;
 
-	sprintf(name, LIBFLAC, FLAC_API_VERSION_CURRENT < 12 ? 8 : FLAC_API_VERSION_CURRENT);
+	sprintf(name, LIBFLAC, FLAC_API_VERSION_CURRENT - FLAC_API_VERSION_AGE);
 
         handle = dlopen(name, RTLD_NOW);
 


### PR DESCRIPTION
Fixes #246.
I checked a bunch of different libFLAC versions, both current and older and I'm pretty sure that this should work for all versions.