### PR TITLE
Change output state from STOPPED to RUNNING

### DIFF
--- a/slimproto.c
+++ b/slimproto.c
@@ -431,7 +431,7 @@ static void process_aude(u8_t *pkt, int len) {
 		output.state = OUTPUT_OFF;
 	}
 	if (aude->enable_spdif && output.state == OUTPUT_OFF && !output.idle_to) {
-		output.state = OUTPUT_STOPPED;
+		output.state = OUTPUT_RUNNING;
 		output.stop_time = gettime_ms();
 	}
 	UNLOCK_O;


### PR DESCRIPTION
I am trying to solve the problem of unmute not working on software players

Currently the unmute command leaves audio silent. Mute works, but unmute requires pause/play to restore sound.

I think this issue is that process_aude() sets output.state = OUTPUT_STOPPED on unmute, but OUTPUT_STOPPED still plays silence (state value 0 is <= OUTPUT_BUFFER value 1).

So this change is to set output.state = OUTPUT_RUNNING instead of OUTPUT_STOPPED. This allows audio playback to resume immediately 

I apologise if there is something I am not understanding about how this works.