### PR TITLE
ir.c: fix build with gcc-15

### DIFF
--- a/ir.c
+++ b/ir.c
@@ -166,7 +166,7 @@ static u32_t ir_key_map(const char *c, const char *r) {
 	return 0;
 }
 
-static void *ir_thread() {
+static void *ir_thread(void *vargp) {
 	char *code;
 	
 	while (fd > 0 && LIRC(i, nextcode, &code) == 0) {


### PR DESCRIPTION
```
ir.c: In function 'ir_init':
ir.c:273:48: error: passing argument 3 of 'pthread_create' from incompatible pointer type [-Wincompatible-pointer-types]
  273 |                 pthread_create(&thread, &attr, ir_thread, NULL);
      |                                                ^~~~~~~~~
      |                                                |
      |                                                void * (*)(void)
In file included from squeezelite.h:300,
                 from ir.c:36:
/home/buildroot/br/output/per-package/squeezelite/host/lib/gcc/x86_64-buildroot-linux-gnu/15.2.0/include-fixed/pthread.h:213:36:
 note: expected 'void * (*)(void *)' but argument is of type 'void * (*)(void)'
  213 |                            void *(*__start_routine) (void *),
      |                            ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
ir.c:169:14: note: 'ir_thread' declared here
  169 | static void *ir_thread() {
      |              ^~~~~~~~~
```