### PR TITLE
Add -F fixed volume CLI option

### DIFF
--- a/doc/squeezelite.1
+++ b/doc/squeezelite.1
@@ -232,6 +232,7 @@ Unmute the given ALSA
 at daemon startup and set it to full volume. Use software volume adjustment for
 playback. This option is mutually exclusive with the \fB\-V\fR option. Only
 applicable when using ALSA output.
+
 .TP
 .B \-V <control>
 Use the given ALSA
@@ -241,6 +242,11 @@ control within \fBsqueezelite\fR. This option is mutually exclusive with the
 \fB\-U\fR option. If neither \fB\-U\fR nor \fB\-V\fR options are provided,
 no ALSA controls are adjusted while running \fBsqueezelite\fR and software
 volume control is used instead. Only applicable when using ALSA output.
+.TP
+.B \-F
+Fix software volume control at 100% and ignore gain adjustment commands from the
+server. This option is mutually exlusive with the \fB\-U\fR and \fB\-V\fR options.
+Only applicable when using ALSA output.
 .TP
 .B \-X
 Use linear volume adjustments instead of in terms of dB (only for

--- a/main.c
+++ b/main.c
@@ -141,6 +141,7 @@ static void usage(const char *argv0) {
 		   "  -U <control>\t\tUnmute ALSA control and set to full volume (not supported with -V)\n"
 		   "  -V <control>\t\tUse ALSA control for volume adjustment, otherwise use software volume adjustment\n"
 		   "  -X \t\t\tUse linear volume adjustments instead of in terms of dB (only for hardware volume control)\n"
+           "  -F \t\t\tFix software volume at 100%%. Ignore volume changes from server\n"
 #endif
 #if LINUX || FREEBSD || SUN
 		   "  -z \t\t\tDaemonize\n"
@@ -325,6 +326,7 @@ int main(int argc, char **argv) {
 	char *output_mixer = NULL;
 	bool output_mixer_unmute = false;
 	bool linear_volume = false;
+    bool fixed_volume = false;
 #endif
 #if DSD
 	unsigned dsd_delay = 0;
@@ -372,7 +374,7 @@ int main(int argc, char **argv) {
 			optind += 2;
 		} else if (strstr("ltz?W"
 #if ALSA
-						  "LX"
+						  "LXF"
 #endif
 #if RESAMPLE
 						  "uR"
@@ -601,13 +603,24 @@ int main(int argc, char **argv) {
 			break;
 		case 'U':
 			output_mixer_unmute = true;
-		case 'V':
-			if (output_mixer) {
-				fprintf(stderr, "-U and -V option should not be used at same time\n");
-				exit(1);
-			}
-			output_mixer = optarg;
-			break;
+        case 'V':
+            if (output_mixer || fixed_volume) {
+                fprintf(
+                    stderr,
+                    "-U, -V, and -F option should not be used at same time\n");
+                exit(1);
+            }
+            output_mixer = optarg;
+            break;
+        case 'F':
+            if (output_mixer) {
+                fprintf(
+                    stderr,
+                    "-U, -V, and -F option should not be used at same time\n");
+                exit(1);
+            }
+            fixed_volume = true;
+            break;
 #endif
 #if IR
 		case 'i':
@@ -781,7 +794,7 @@ int main(int argc, char **argv) {
 	} else {
 #if ALSA
 		output_init_alsa(log_output, output_device, output_buf_size, output_params, rates, rate_delay, rt_priority, idle, mixer_device, output_mixer,
-						 output_mixer_unmute, linear_volume);
+						 output_mixer_unmute, linear_volume, fixed_volume);
 #endif
 #if PORTAUDIO
 		output_init_pa(log_output, output_device, output_buf_size, output_params, rates, rate_delay, idle);

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -66,6 +66,7 @@ static struct {
 	snd_mixer_t *mixer_handle;
 	long mixer_min;
 	long mixer_max;
+    bool fixed_volume;
 } alsa;
 
 static snd_pcm_t *pcmp = NULL;
@@ -228,6 +229,11 @@ static void set_mixer(bool setmax, float ldB, float rdB) {
 
 void set_volume(unsigned left, unsigned right) {
 	float ldB, rdB;
+
+    if(alsa.fixed_volume) {
+        LOG_DEBUG("ignoring gain adjustment command");
+        return;
+    }
 
 	if (!alsa.volume_mixer_name) {
 		LOG_DEBUG("setting internal gain left: %u right: %u", left, right);
@@ -908,7 +914,7 @@ int mixer_init_alsa(const char *device, const char *mixer, int mixer_index) {
 
 static pthread_t thread;
 
-void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear) {
+void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, bool fixed_volume) {
 
 	unsigned alsa_buffer = ALSA_BUFFER_TIME;
 	unsigned alsa_period = ALSA_PERIOD_COUNT;
@@ -992,6 +998,13 @@ void output_init_alsa(log_level level, const char *device, unsigned output_buf_s
 		set_mixer(true, 0, 0);
 		alsa.volume_mixer_name = NULL;
 	}
+
+    alsa.fixed_volume = fixed_volume;
+    if(fixed_volume) {
+        // Set initial gains
+        output.gainL = FIXED_ONE;
+        output.gainR = FIXED_ONE;
+    }
 
 #if LINUX
 	// RT linux - aim to avoid pagefaults by locking memory: 

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -714,7 +714,7 @@ void list_devices(void);
 void list_mixers(const char *output_device);
 void set_volume(unsigned left, unsigned right);
 bool test_open(const char *device, unsigned rates[], bool userdef_rates);
-void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear);
+void output_init_alsa(log_level level, const char *device, unsigned output_buf_size, char *params, unsigned rates[], unsigned rate_delay, unsigned rt_priority, unsigned idle, char *mixer_device, char *volume_mixer, bool mixer_unmute, bool mixer_linear, bool fixed_volume);
 void output_close_alsa(void);
 #endif
 


### PR DESCRIPTION
Hi, I have made a few simple changes that add the option to disable software volume control when using ALSA outputs. Is this something you would be interested in merging?

The option works as follows:

- User specifies '-F' option
- When opening the ALSA output, squeezelite sets internal volume (gainL and gainR) to FIXED_ONE (full volume)
- Every subsequente "audg" request from the server is ignored, volume stays at 100%

Please follow up with any adjustments you deem necessary.