### PR TITLE
Add support for external volume scripts with -w

### DIFF
--- a/doc/squeezelite.1
+++ b/doc/squeezelite.1
@@ -242,6 +242,10 @@ control within \fBsqueezelite\fR. This option is mutually exclusive with the
 no ALSA controls are adjusted while running \fBsqueezelite\fR and software
 volume control is used instead. Only applicable when using ALSA output.
 .TP
+.B \-w <volume script>
+Absolute path to script that launches on volume commands from LMS (passes 0-100
+as first argument). This cannot be used with the \fB-V\fR option.
+.TP
 .B \-X
 Use linear volume adjustments instead of in terms of dB (only for
 hardware volume control).

--- a/doc/squeezelite.1
+++ b/doc/squeezelite.1
@@ -222,6 +222,13 @@ process this to create visualisations.
 .B \-W
 Read wave and aiff format from header, ignoring server parameters.
 .TP
+.B \-w <script>
+Absolute path to an executable script to invoke on volume commands from LMS.
+The script is passed a single integer argument in the range 0\-100, where 0 is
+silence and 100 is full volume, mapped from the LMS dB range (\-72..0 dB) using
+the same linear scale as the ALSA volume control. This option is mutually
+exclusive with the \fB\-V\fR option.
+.TP
 .B \-L
 List available volume controls for the output device. Only applicable when
 using ALSA output.

--- a/main.c
+++ b/main.c
@@ -26,6 +26,8 @@
 
 #include <signal.h>
 
+char *volume_script = NULL;
+
 #define TITLE "Squeezelite " VERSION ", Copyright 2012-2015 Adrian Smith, 2015-2025 Ralph Irving."
 
 #define CODECS_BASE "flac,pcm,ogg"
@@ -104,6 +106,7 @@ static void usage(const char *argv0) {
 		   "  -n <name>\t\tSet the player name\n"
 		   "  -N <filename>\t\tStore player name in filename to allow server defined name changes to be shared between servers (not supported with -n)\n"
 		   "  -W\t\t\tRead wave and aiff format from header, ignore server parameters\n"
+		   "  -w <script>\t\tAbsolute path to script to launch on volume commands from LMS (not supported with -V)\n"
 #if ALSA
 		   "  -p <priority>\t\tSet real time priority of output thread (1-99)\n"
 #endif
@@ -296,9 +299,6 @@ static void sighandler(int signum) {
 	signal(signum, SIG_DFL);
 }
 
-// Global variable for external volume script
-char *volume_script = NULL;
-
 int main(int argc, char **argv) {
 	char *server = NULL;
 	char *output_device = "default";
@@ -367,7 +367,7 @@ int main(int argc, char **argv) {
 
 	while (optind < argc && strlen(argv[optind]) >= 2 && argv[optind][0] == '-') {
 		char *opt = argv[optind] + 1;
-		if (strstr("oabcCdefmMnNpPrsZ"
+		if (strstr("oabcCdefmMnNpPrsZw"
 #if ALSA
 				   "UVwO"
 #endif
@@ -614,15 +614,18 @@ int main(int argc, char **argv) {
 			break;
 #endif
 		case 'w':
-			if (output_mixer_unmute) {
-				fprintf(stderr, "-U and -w option should not be used at same time\n");
-				exit(1);
-			}
+#if ALSA
 			if (output_mixer) {
-				fprintf(stderr, "-V and -w option should not be used at same time\n");
+				fprintf(stderr, "-V and -w options cannot be used at same time\n");
 				exit(1);
 			}
+#endif
 			volume_script = optarg;
+			if (access(volume_script, R_OK|X_OK) == -1) {
+				fprintf(stderr, "Script %s not found or not executable\n\n", volume_script);
+				usage(argv[0]);
+				exit(1);
+			}
 			break;
 #if IR
 		case 'i':

--- a/main.c
+++ b/main.c
@@ -112,7 +112,7 @@ static void usage(const char *argv0) {
 #endif
 		   "  -r <rates>[:<delay>]\tSample rates supported, allows output to be off when squeezelite is started; rates = <maxrate>|<minrate>-<maxrate>|<rate1>,<rate2>,<rate3>; delay = optional delay switching rates in ms\n"
 #if GPIO
-			"  -S <Power Script>\tAbsolute path to script to launch on power commands from LMS\n"
+			"  -S <power script>\tAbsolute path to script that launches on power commands from LMS\n"
 #endif
 #if RESAMPLE
 		   "  -R -u [params]\tResample, params = <recipe>:<flags>:<attenuation>:<precision>:<passband_end>:<stopband_start>:<phase_response>,\n" 
@@ -140,6 +140,7 @@ static void usage(const char *argv0) {
 		   "  -L \t\t\tList volume controls for output device\n"
 		   "  -U <control>\t\tUnmute ALSA control and set to full volume (not supported with -V)\n"
 		   "  -V <control>\t\tUse ALSA control for volume adjustment, otherwise use software volume adjustment\n"
+		   "  -w <volume script>\t\tAbsolute path to script that launches on volume commands from LMS (passes 0-100 as first argument, not supported with -V)\n"
 		   "  -X \t\t\tUse linear volume adjustments instead of in terms of dB (only for hardware volume control)\n"
 #endif
 #if LINUX || FREEBSD || SUN
@@ -295,6 +296,9 @@ static void sighandler(int signum) {
 	signal(signum, SIG_DFL);
 }
 
+// Global variable for external volume script
+char *volume_script = NULL;
+
 int main(int argc, char **argv) {
 	char *server = NULL;
 	char *output_device = "default";
@@ -365,7 +369,7 @@ int main(int argc, char **argv) {
 		char *opt = argv[optind] + 1;
 		if (strstr("oabcCdefmMnNpPrsZ"
 #if ALSA
-				   "UVO"
+				   "UVwO"
 #endif
 				   , opt) && optind < argc - 1) {
 			optarg = argv[optind + 1];
@@ -609,6 +613,17 @@ int main(int argc, char **argv) {
 			output_mixer = optarg;
 			break;
 #endif
+		case 'w':
+			if (output_mixer_unmute) {
+				fprintf(stderr, "-U and -w option should not be used at same time\n");
+				exit(1);
+			}
+			if (output_mixer) {
+				fprintf(stderr, "-V and -w option should not be used at same time\n");
+				exit(1);
+			}
+			volume_script = optarg;
+			break;
 #if IR
 		case 'i':
 			if (optind < argc && argv[optind] && argv[optind][0] != '-') {

--- a/output.c
+++ b/output.c
@@ -22,6 +22,7 @@
 // Common output function
 
 #include "squeezelite.h"
+#include <math.h>
 
 static log_level loglevel;
 
@@ -286,6 +287,35 @@ frames_t _output_frames(frames_t avail) {
 	LOG_SDEBUG("wrote %u frames", frames);
 
 	return frames;
+}
+
+void call_volume_script(unsigned left) {
+	char cmd[256];
+	float ldB;
+	int vol;
+
+	LOCK;
+	if (output.state == OUTPUT_OFF) {
+		UNLOCK;
+		return;
+	}
+	UNLOCK;
+
+	ldB = 20.0f * log10f((float)left / FIXED_ONE);
+	vol = (int)lroundf((ldB > -72.0f ? 72.0f + ldB : 0.0f) / 72.0f * 100.0f);
+	LOG_DEBUG("volume script left: %u ldB: %.1f vol: %u", left, ldB, vol);
+#if defined(_WIN32) || defined(_WIN64)
+	snprintf(cmd, sizeof(cmd), "start /B %s %u", volume_script, vol);
+#else
+	snprintf(cmd, sizeof(cmd), "%s %u &", volume_script, vol);
+#endif
+	if (system(cmd) != 0) {
+		LOG_ERROR("external volume script failed: %s", cmd);
+	}
+	LOCK;
+	output.gainL = FIXED_ONE;
+	output.gainR = FIXED_ONE;
+	UNLOCK;
 }
 
 void _checkfade(bool start) {

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -229,6 +229,53 @@ static void set_mixer(bool setmax, float ldB, float rdB) {
 void set_volume(unsigned left, unsigned right) {
 	float ldB, rdB;
 
+	// if external volume script is set, call it
+	if (volume_script) {
+		char cmd[256];
+
+		// Fix official Boom/SqueezePlay curve glitches, works perfectly with 2% volume steps
+		if (left == 2048){ // 39 --> 40
+			left = 2146;
+		} else if (left == 2304){ // 41 --> 42
+			left = 2406;
+		} else if (left == 2816){ // 45 --> 44
+			left = 2689;
+		}
+
+		// use left channel as the main volume value
+		ldB = 20 * log10( left  / 65536.0F );
+
+		// Choose a floor that matches typical LMS low end (~ -72 dB from the table’s 1% value)
+		const double dB_min = -49.510895;
+		const double dB_max = 0.0;
+
+		int vol = 0;
+		if (ldB <= dB_min){
+			vol = 0;
+		} else if (ldB >= dB_max){
+			vol = 100;
+		} else {
+			vol = (int)lround( (ldB - dB_min) * 100.0 / (dB_max - dB_min) );
+		}
+		LOG_DEBUG("left: %u, ldB:%f vol: %u", left, ldB, vol);
+
+		// Run the external script asynchronously to avoid blocking
+	#if defined(_WIN32) || defined(_WIN64)
+		snprintf(cmd, sizeof(cmd), "start /B %s %u", volume_script, vol);
+	#else
+		snprintf(cmd, sizeof(cmd), "%s %u &", volume_script, vol);
+	#endif
+		int ret = system(cmd);
+		if (ret != 0) {
+			LOG_ERROR("external volume script failed: %s", cmd);
+		}
+		LOCK;
+		output.gainL = FIXED_ONE;
+		output.gainR = FIXED_ONE;
+		UNLOCK;
+		return;
+	}
+
 	if (!alsa.volume_mixer_name) {
 		LOG_DEBUG("setting internal gain left: %u right: %u", left, right);
 		LOCK;

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -229,50 +229,8 @@ static void set_mixer(bool setmax, float ldB, float rdB) {
 void set_volume(unsigned left, unsigned right) {
 	float ldB, rdB;
 
-	// if external volume script is set, call it
 	if (volume_script) {
-		char cmd[256];
-
-		// Fix official Boom/SqueezePlay curve glitches, works perfectly with 2% volume steps
-		if (left == 2048){ // 39 --> 40
-			left = 2146;
-		} else if (left == 2304){ // 41 --> 42
-			left = 2406;
-		} else if (left == 2816){ // 45 --> 44
-			left = 2689;
-		}
-
-		// use left channel as the main volume value
-		ldB = 20 * log10( left  / 65536.0F );
-
-		// Choose a floor that matches typical LMS low end (~ -72 dB from the table’s 1% value)
-		const double dB_min = -49.510895;
-		const double dB_max = 0.0;
-
-		int vol = 0;
-		if (ldB <= dB_min){
-			vol = 0;
-		} else if (ldB >= dB_max){
-			vol = 100;
-		} else {
-			vol = (int)lround( (ldB - dB_min) * 100.0 / (dB_max - dB_min) );
-		}
-		LOG_DEBUG("left: %u, ldB:%f vol: %u", left, ldB, vol);
-
-		// Run the external script asynchronously to avoid blocking
-	#if defined(_WIN32) || defined(_WIN64)
-		snprintf(cmd, sizeof(cmd), "start /B %s %u", volume_script, vol);
-	#else
-		snprintf(cmd, sizeof(cmd), "%s %u &", volume_script, vol);
-	#endif
-		int ret = system(cmd);
-		if (ret != 0) {
-			LOG_ERROR("external volume script failed: %s", cmd);
-		}
-		LOCK;
-		output.gainL = FIXED_ONE;
-		output.gainR = FIXED_ONE;
-		UNLOCK;
+		call_volume_script(left);
 		return;
 	}
 

--- a/output_pa.c
+++ b/output_pa.c
@@ -108,6 +108,50 @@ void list_devices(void) {
 }
 
 void set_volume(unsigned left, unsigned right) {
+
+	// if external volume script is set, call it
+	if (volume_script) {
+		char cmd[256];
+
+		// Fix official Boom/SqueezePlay curve glitches, works perfectly with 2% volume steps
+		if (left == 2048){ // 39 --> 40
+			left = 2146;
+		} else if (left == 2304){ // 41 --> 42
+			left = 2406;
+		} else if (left == 2816){ // 45 --> 44
+			left = 2689;
+		}
+
+		// use left channel as the main volume value
+		float ldB = 20 * log10( left  / 65536.0F );
+
+		// Choose a floor that matches typical LMS low end (~ -72 dB from the table’s 1% value)
+		const double dB_min = -49.510895;
+		const double dB_max = 0.0;
+
+		int vol = 0;
+		if (ldB <= dB_min){
+			vol = 0;
+		} else if (ldB >= dB_max){
+			vol = 100;
+		} else {
+			vol = (int)lround( (ldB - dB_min) * 100.0 / (dB_max - dB_min) );
+		}
+		LOG_DEBUG("left: %u, ldB:%f vol: %u", left, ldB, vol);
+
+		snprintf(cmd, sizeof(cmd), "%s %u", volume_script, vol);
+
+		int ret = system(cmd);
+		if (ret != 0) {
+			LOG_ERROR("external volume script failed: %s", cmd);
+		}
+		LOCK;
+		output.gainL = FIXED_ONE;
+		output.gainR = FIXED_ONE;
+		UNLOCK;
+		return;
+	}
+
 	LOG_DEBUG("setting internal gain left: %u right: %u", left, right);
 	LOCK;
 	output.gainL = left;

--- a/output_pa.c
+++ b/output_pa.c
@@ -108,50 +108,10 @@ void list_devices(void) {
 }
 
 void set_volume(unsigned left, unsigned right) {
-
-	// if external volume script is set, call it
 	if (volume_script) {
-		char cmd[256];
-
-		// Fix official Boom/SqueezePlay curve glitches, works perfectly with 2% volume steps
-		if (left == 2048){ // 39 --> 40
-			left = 2146;
-		} else if (left == 2304){ // 41 --> 42
-			left = 2406;
-		} else if (left == 2816){ // 45 --> 44
-			left = 2689;
-		}
-
-		// use left channel as the main volume value
-		float ldB = 20 * log10( left  / 65536.0F );
-
-		// Choose a floor that matches typical LMS low end (~ -72 dB from the table’s 1% value)
-		const double dB_min = -49.510895;
-		const double dB_max = 0.0;
-
-		int vol = 0;
-		if (ldB <= dB_min){
-			vol = 0;
-		} else if (ldB >= dB_max){
-			vol = 100;
-		} else {
-			vol = (int)lround( (ldB - dB_min) * 100.0 / (dB_max - dB_min) );
-		}
-		LOG_DEBUG("left: %u, ldB:%f vol: %u", left, ldB, vol);
-
-		snprintf(cmd, sizeof(cmd), "%s %u", volume_script, vol);
-
-		int ret = system(cmd);
-		if (ret != 0) {
-			LOG_ERROR("external volume script failed: %s", cmd);
-		}
-		LOCK;
-		output.gainL = FIXED_ONE;
-		output.gainR = FIXED_ONE;
-		UNLOCK;
+		call_volume_script(left);
 		return;
 	}
-
 	LOG_DEBUG("setting internal gain left: %u right: %u", left, right);
 	LOCK;
 	output.gainL = left;

--- a/output_pulse.c
+++ b/output_pulse.c
@@ -317,6 +317,50 @@ static void pulse_set_volume(struct pulse *p, unsigned left, unsigned right) {
 }
 
 void set_volume(unsigned left, unsigned right) {
+
+	// if external volume script is set, call it
+	if (volume_script) {
+		char cmd[256];
+
+		// Fix official Boom/SqueezePlay curve glitches, works perfectly with 2% volume steps
+		if (left == 2048){ // 39 --> 40
+			left = 2146;
+		} else if (left == 2304){ // 41 --> 42
+			left = 2406;
+		} else if (left == 2816){ // 45 --> 44
+			left = 2689;
+		}
+
+		// use left channel as the main volume value
+		float ldB = 20 * log10( left  / 65536.0F );
+
+		// Choose a floor that matches typical LMS low end (~ -72 dB from the table’s 1% value)
+		const double dB_min = -49.510895;
+		const double dB_max = 0.0;
+
+		int vol = 0;
+		if (ldB <= dB_min){
+			vol = 0;
+		} else if (ldB >= dB_max){
+			vol = 100;
+		} else {
+			vol = (int)lround( (ldB - dB_min) * 100.0 / (dB_max - dB_min) );
+		}
+		LOG_DEBUG("left: %u, ldB:%f vol: %u", left, ldB, vol);
+
+		snprintf(cmd, sizeof(cmd), "%s %u", volume_script, vol);
+
+		int ret = system(cmd);
+		if (ret != 0) {
+			LOG_ERROR("external volume script failed: %s", cmd);
+		}
+		LOCK;
+		output.gainL = FIXED_ONE;
+		output.gainR = FIXED_ONE;
+		UNLOCK;
+		return;
+	}
+
 	bool adjust_sink_input = false;
 
 	LOCK;

--- a/output_pulse.c
+++ b/output_pulse.c
@@ -363,6 +363,11 @@ void set_volume(unsigned left, unsigned right) {
 
 	bool adjust_sink_input = false;
 
+	if (volume_script) {
+		call_volume_script(left);
+		return;
+	}
+
 	LOCK;
 	adjust_sink_input = (left != output.gainL) || (right != output.gainR);
 	output.gainL = left;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -821,3 +821,5 @@ void free_ssl_symbols(void);
 bool ssl_loaded;
 #endif
 
+// External volume script path (set by -w option)
+extern char *volume_script;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -821,5 +821,7 @@ void free_ssl_symbols(void);
 bool ssl_loaded;
 #endif
 
-// External volume script path (set by -w option)
+// output.c / main.c
 extern char *volume_script;
+void call_volume_script(unsigned left);
+


### PR DESCRIPTION
This is useful, if the client should have a fixed volume and an external amplifier should be controlled. This helps to prevent clipping and big volume differences when changing channel on the external amplifier.

Here a few cases:
- You have connected a Raspberry Pi via HDMI to an AV receiver. The volume between Raspberry Pi and AV receiver should be fixed at an optimum that prevents clipping. The volume is changed directly on the AV receiver via CEC or HTTP API.
- A Raspberry Pi is connected to an external custom made amplifier that can be controlled via Modbus.

Fixes https://github.com/ralph-irving/squeezelite/issues/257