### PR TITLE
Add -w option to call external volume script on LMS volume changes

### DIFF
--- a/doc/squeezelite.1
+++ b/doc/squeezelite.1
@@ -222,6 +222,13 @@ process this to create visualisations.
 .B \-W
 Read wave and aiff format from header, ignoring server parameters.
 .TP
+.B \-w <script>
+Absolute path to an executable script to invoke on volume commands from LMS.
+The script is passed a single integer argument in the range 0\-100, where 0 is
+silence and 100 is full volume, mapped from the LMS dB range (\-72..0 dB) using
+the same linear scale as the ALSA volume control. This option is mutually
+exclusive with the \fB\-V\fR option.
+.TP
 .B \-L
 List available volume controls for the output device. Only applicable when
 using ALSA output.

--- a/main.c
+++ b/main.c
@@ -26,6 +26,8 @@
 
 #include <signal.h>
 
+char *volume_script = NULL;
+
 #define TITLE "Squeezelite " VERSION ", Copyright 2012-2015 Adrian Smith, 2015-2026 Ralph Irving."
 
 #define CODECS_BASE "flac,pcm,ogg"
@@ -104,6 +106,7 @@ static void usage(const char *argv0) {
 		   "  -n <name>\t\tSet the player name\n"
 		   "  -N <filename>\t\tStore player name in filename to allow server defined name changes to be shared between servers (not supported with -n)\n"
 		   "  -W\t\t\tRead wave and aiff format from header, ignore server parameters\n"
+		   "  -w <script>\t\tAbsolute path to script to launch on volume commands from LMS (not supported with -V)\n"
 #if ALSA
 		   "  -p <priority>\t\tSet real time priority of output thread (1-99)\n"
 #endif
@@ -363,7 +366,7 @@ int main(int argc, char **argv) {
 
 	while (optind < argc && strlen(argv[optind]) >= 2 && argv[optind][0] == '-') {
 		char *opt = argv[optind] + 1;
-		if (strstr("oabcCdefmMnNpPrsZ"
+		if (strstr("oabcCdefmMnNpPrsZw"
 #if ALSA
 				   "UVO"
 #endif
@@ -609,6 +612,20 @@ int main(int argc, char **argv) {
 			output_mixer = optarg;
 			break;
 #endif
+		case 'w':
+#if ALSA
+			if (output_mixer) {
+				fprintf(stderr, "-V and -w options cannot be used at same time\n");
+				exit(1);
+			}
+#endif
+			volume_script = optarg;
+			if (access(volume_script, R_OK|X_OK) == -1) {
+				fprintf(stderr, "Script %s not found or not executable\n\n", volume_script);
+				usage(argv[0]);
+				exit(1);
+			}
+			break;
 #if IR
 		case 'i':
 			if (optind < argc && argv[optind] && argv[optind][0] != '-') {

--- a/output.c
+++ b/output.c
@@ -22,6 +22,7 @@
 // Common output function
 
 #include "squeezelite.h"
+#include <math.h>
 
 static log_level loglevel;
 
@@ -286,6 +287,35 @@ frames_t _output_frames(frames_t avail) {
 	LOG_SDEBUG("wrote %u frames", frames);
 
 	return frames;
+}
+
+void call_volume_script(unsigned left) {
+	char cmd[256];
+	float ldB;
+	int vol;
+
+	LOCK;
+	if (output.state == OUTPUT_OFF) {
+		UNLOCK;
+		return;
+	}
+	UNLOCK;
+
+	ldB = 20.0f * log10f((float)left / FIXED_ONE);
+	vol = (int)lroundf((ldB > -72.0f ? 72.0f + ldB : 0.0f) / 72.0f * 100.0f);
+	LOG_DEBUG("volume script left: %u ldB: %.1f vol: %u", left, ldB, vol);
+#if defined(_WIN32) || defined(_WIN64)
+	snprintf(cmd, sizeof(cmd), "start /B %s %u", volume_script, vol);
+#else
+	snprintf(cmd, sizeof(cmd), "%s %u &", volume_script, vol);
+#endif
+	if (system(cmd) != 0) {
+		LOG_ERROR("external volume script failed: %s", cmd);
+	}
+	LOCK;
+	output.gainL = FIXED_ONE;
+	output.gainR = FIXED_ONE;
+	UNLOCK;
 }
 
 void _checkfade(bool start) {

--- a/output_alsa.c
+++ b/output_alsa.c
@@ -229,6 +229,11 @@ static void set_mixer(bool setmax, float ldB, float rdB) {
 void set_volume(unsigned left, unsigned right) {
 	float ldB, rdB;
 
+	if (volume_script) {
+		call_volume_script(left);
+		return;
+	}
+
 	if (!alsa.volume_mixer_name) {
 		LOG_DEBUG("setting internal gain left: %u right: %u", left, right);
 		LOCK;

--- a/output_pa.c
+++ b/output_pa.c
@@ -108,6 +108,10 @@ void list_devices(void) {
 }
 
 void set_volume(unsigned left, unsigned right) {
+	if (volume_script) {
+		call_volume_script(left);
+		return;
+	}
 	LOG_DEBUG("setting internal gain left: %u right: %u", left, right);
 	LOCK;
 	output.gainL = left;

--- a/output_pulse.c
+++ b/output_pulse.c
@@ -319,6 +319,11 @@ static void pulse_set_volume(struct pulse *p, unsigned left, unsigned right) {
 void set_volume(unsigned left, unsigned right) {
 	bool adjust_sink_input = false;
 
+	if (volume_script) {
+		call_volume_script(left);
+		return;
+	}
+
 	LOCK;
 	adjust_sink_input = (left != output.gainL) || (right != output.gainR);
 	output.gainL = left;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -821,3 +821,7 @@ void free_ssl_symbols(void);
 bool ssl_loaded;
 #endif
 
+// output.c / main.c
+extern char *volume_script;
+void call_volume_script(unsigned left);
+


### PR DESCRIPTION
Supersedes #258. Addresses the issues raised in that PR's comments.

## What this does

Adds a `-w <script>` option that invokes an executable script whenever LMS sends a volume command (AUDG packet). The script receives a single integer argument 0–100 mapped from the LMS dB range (−72..0 dB) using the same linear scale that the ALSA mixer path already uses. When `-w` is active the internal software gain is held at unity (FIXED_ONE) so the script has full control over output level.

## Changes vs #258

- **Shared helper**: `call_volume_script()` is placed in `output.c` (always compiled) instead of being copy-pasted into each backend. ALSA, PortAudio and PulseAudio backends each call it with a 4-line guard.
- **Correct dB mapping**: mirrors ALSA's existing `MINVOL_DB = 72` linear mapping instead of the hardcoded −49.5 dB floor in the original, which caused vol=0 for any LMS volume ≤ 16%.
- **Skip on power-off**: `call_volume_script()` returns immediately when `output.state == OUTPUT_OFF`, so LMS's fade-to-off AUDG sequence does not reach the script.
- **Async launch**: script is always launched with `&` on POSIX (`start /B` on Windows) so the audio thread is not blocked.
- **-V conflict check**: `-w` and `-V` (ALSA hardware volume) are mutually exclusive; passing both prints an error and exits.
- **Man page**: `-w` option documented in `doc/squeezelite.1`.
- **No unrelated changes**: single commit, no copyright year or version bumps.