### PR TITLE
Support "20-bit" flac audio

### DIFF
--- a/flac.c
+++ b/flac.c
@@ -233,7 +233,12 @@ static FLAC__StreamDecoderWriteStatus write_cb(const FLAC__StreamDecoder *decode
 				*optr++ = ALIGN16(*lptr++);
 				*optr++ = ALIGN16(*rptr++);
 			}
-		} else if (bits_per_sample == 24) {
+		} else if (bits_per_sample == 20) {
+			while (count--) {
+				*optr++ = ALIGN24(*lptr++ << 4);
+				*optr++ = ALIGN24(*rptr++ << 4);
+			}
+		} else if ( bits_per_sample == 24) {
 			while (count--) {
 				*optr++ = ALIGN24(*lptr++);
 				*optr++ = ALIGN24(*rptr++);


### PR DESCRIPTION
Hi,

Is there some reason to not support 20-bit audio? I have several HDCDs I've ripped with CueRipper and decoded with CueTools as "20-bit flac" files.

```bash
$ ffprobe 02\ Harvest.flac 2>&1 | grep "20 bit"
  Stream #0:0: Audio: flac, 44100 Hz, stereo, s32 (20 bit)
$ ffprobe -loglevel 0 -show_streams 02\ Harvest.flac | grep bits_per
bits_per_sample=0
bits_per_raw_sample=20
bits_per_raw_sample=8
```

I don't have a lot of c audio expertise but I tested this fix on my mac and it worked fine.
